### PR TITLE
Medical - Revise resilience regeneration rate for second chance

### DIFF
--- a/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
@@ -4,7 +4,7 @@
 //! Add methods for interacting with pain hit zone.
 modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 {
-	[RplProp(), Attribute(defvalue: "0.025", desc: "Resilience regeneration scale when second chance was triggered. The default regeneration rate will be multiplied by this factor.", category: "ACE Medical")]
+	[RplProp(), Attribute(defvalue: "0", desc: "Resilience regeneration scale when second chance was triggered. The default regeneration rate will be multiplied by this factor.", category: "ACE Medical")]
 	protected float m_fACE_Medical_SecondChanceRegenScale;
 
 	protected HitZone m_pACE_Medical_HealthHitZone;
@@ -52,7 +52,7 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 		if (settings)
 		{
 			m_bACE_Medical_SecondChanceOnHeadEnabled = settings.m_bSecondChanceOnHeadEnabled;
-			m_fACE_Medical_SecondChanceRegenScale = 1/settings.m_fSecondChanceRegenTimeFactor;
+			m_fACE_Medical_SecondChanceRegenScale = settings.m_fSecondChanceRegenScale;
 		}
 		
 		ACE_Medical_EnableSecondChance(true);

--- a/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
@@ -4,8 +4,8 @@
 //! Add methods for interacting with pain hit zone.
 modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 {
-	[Attribute(defvalue: "600", desc: "Time to regenerate this hit zone fully in second chance state [s]", category: "ACE Medical")]
-	protected float m_fACE_Medical_SecondChanceFullRegenetationTimeS;
+	[RplProp(), Attribute(defvalue: "0.025", desc: "Resilience regeneration scale when second chance was triggered. The default regeneration rate will be multiplied by this factor.", category: "ACE Medical")]
+	protected float m_fACE_Medical_SecondChanceRegenScale;
 
 	protected HitZone m_pACE_Medical_HealthHitZone;
 	protected float m_fACE_Medical_CriticalHealth;
@@ -26,7 +26,6 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 	protected bool m_bACE_Medical_SecondChanceOnHeadEnabled = false;
 	[RplProp()]
 	protected bool m_bACE_Medical_SecondChanceTriggered = false;
-	protected float m_fACE_Medical_SecondChanceRegenScale;
 	
 	//-----------------------------------------------------------------------------------------------------------
 	//! Initialize member variables
@@ -40,8 +39,6 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 		
 		m_fACE_Medical_CriticalHealth = m_pACE_Medical_HealthHitZone.GetDamageStateThreshold(ECharacterHealthState.CRITICAL);
 		GetPhysicalHitZones(m_aACE_Medical_PhysicalHitZones);
-		
-		m_fACE_Medical_SecondChanceRegenScale = -GetResilienceHitZone().GetMaxHealth() / m_fACE_Medical_SecondChanceFullRegenetationTimeS;
 	}
 	
 	//-----------------------------------------------------------------------------------------------------------
@@ -53,7 +50,10 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 				
 		ACE_Medical_Settings settings = ACE_SettingsHelperT<ACE_Medical_Settings>.GetModSettings();
 		if (settings)
+		{
 			m_bACE_Medical_SecondChanceOnHeadEnabled = settings.m_bSecondChanceOnHeadEnabled;
+			m_fACE_Medical_SecondChanceRegenScale = 1/settings.m_fSecondChanceRegenTimeFactor;
+		}
 		
 		ACE_Medical_EnableSecondChance(true);
 		// Damage calculations are done on all machines, so we have to broadcast the init

--- a/addons/medical/scripts/Game/ACE_Medical/Settings/ACE_Medical_SettingsConfig.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Settings/ACE_Medical_SettingsConfig.c
@@ -3,6 +3,9 @@
 [BaseContainerProps()]
 class ACE_Medical_Settings : ACE_ModSettings
 {
+	[Attribute(defvalue: "40", desc: "Determines how many times longer it takes to fully regenerate resilience when second chance was triggered", category: "ACE Medical")]
+	float m_fSecondChanceRegenTimeFactor;
+	
 	[Attribute(defvalue: "false", desc: "Enables second chance on headshots")]
 	bool m_bSecondChanceOnHeadEnabled;
 	

--- a/addons/medical/scripts/Game/ACE_Medical/Settings/ACE_Medical_SettingsConfig.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Settings/ACE_Medical_SettingsConfig.c
@@ -3,8 +3,8 @@
 [BaseContainerProps()]
 class ACE_Medical_Settings : ACE_ModSettings
 {
-	[Attribute(defvalue: "40", desc: "Determines how many times longer it takes to fully regenerate resilience when second chance was triggered", category: "ACE Medical")]
-	float m_fSecondChanceRegenTimeFactor;
+	[Attribute(defvalue: "0", desc: "Resilience regeneration scale when second chance was triggered. The default regeneration rate will be multiplied by this factor.", category: "ACE Medical")]
+	float m_fSecondChanceRegenScale;
 	
 	[Attribute(defvalue: "false", desc: "Enables second chance on headshots")]
 	bool m_bSecondChanceOnHeadEnabled;

--- a/docs/src/content/docs/components/medical.mdx
+++ b/docs/src/content/docs/components/medical.mdx
@@ -19,11 +19,12 @@ Second chance gets triggered when a player would have been killed without fallin
 
 Certain aspects of the medical system can be configured in the mission header section of a server config file. An overview of available fields is given below in the table:
 
-| Field                        | Type  | Default | Description                                                                                          |
-| ---------------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------- |
-| m_bSecondChanceOnHeadEnabled | bool  | false   | Enables second chance on headshots.                                                                  |
-| m_bHealSupplyUsageEnabled    | bool  | true    | Healing consumes supplies when enabled. Ignored when global supply usage is disabled.                |
-| m_fMedicalKitMaxHealScaled   | float | 0.5     | Maximum scaled health (from 0.0 to 1.0) that a medical kit can heal outside of medical facilities.   |
+| Field                          | Type  | Default | Description                                                                                          |
+| ------------------------------ | ----- | ------- | ---------------------------------------------------------------------------------------------------- |
+| m_fSecondChanceRegenTimeFactor | float | 40      | Determines how many times longer it takes to fully regenerate resilience when second chance was triggered. The default full recovery time is 20 s, which means 800 s when second chance was triggered when set to 40.  |
+| m_bSecondChanceOnHeadEnabled   | bool  | false   | Enables second chance on headshots.                                                                  |
+| m_bHealSupplyUsageEnabled      | bool  | true    | Healing consumes supplies when enabled. Ignored when global supply usage is disabled.                |
+| m_fMedicalKitMaxHealScaled     | float | 0.5     | Maximum scaled health (from 0.0 to 1.0) that a medical kit can heal outside of medical facilities.   |
 
 Example for the `missionHeader` in a server config:
 ```

--- a/docs/src/content/docs/components/medical.mdx
+++ b/docs/src/content/docs/components/medical.mdx
@@ -13,7 +13,7 @@ Note that ACE Medical currently only affects players, but not AI.
 
 ### Second Chance
 
-Second chance gets triggered when a player would have been killed without falling unconscious first. Instead of dying, the player will stay alive with 1 HP. On the other hand, natural recovery from this state is very slow (up to 10 minutes without epinephrine). Second chance is deactivated for headshots by default.
+Second chance gets triggered when a player would have been killed without falling unconscious first. Instead of dying, the player will stay alive with 1 HP. On the other hand, they can only wake up from this state when epinephrine was administered (Automatic wake-up can be enabled by changing `m_fSecondChanceRegenScale` to a value above zero). Second chance is deactivated for headshots by default.
 
 ## Settings
 
@@ -21,7 +21,7 @@ Certain aspects of the medical system can be configured in the mission header se
 
 | Field                          | Type  | Default | Description                                                                                          |
 | ------------------------------ | ----- | ------- | ---------------------------------------------------------------------------------------------------- |
-| m_fSecondChanceRegenTimeFactor | float | 40      | Determines how many times longer it takes to fully regenerate resilience when second chance was triggered. The default full recovery time is 20 s, which means 800 s when second chance was triggered when set to 40.  |
+| m_fSecondChanceRegenScale      | float | 0.0     | Scales the unconsciousness recovery rate when second chance was triggered. The default recovery rate (full recovery in 20 s) will be multiplied by this factor. Note that recovery only starts 10 s after the last incoming damage. |
 | m_bSecondChanceOnHeadEnabled   | bool  | false   | Enables second chance on headshots.                                                                  |
 | m_bHealSupplyUsageEnabled      | bool  | true    | Healing consumes supplies when enabled. Ignored when global supply usage is disabled.                |
 | m_fMedicalKitMaxHealScaled     | float | 0.5     | Maximum scaled health (from 0.0 to 1.0) that a medical kit can heal outside of medical facilities.   |
@@ -31,6 +31,7 @@ Example for the `missionHeader` in a server config:
 "missionHeader": {
     "m_ACE_Settings": {
         "m_ACE_Medical_Settings": {
+            "m_fSecondChanceRegenScale": 0.025,
             "m_bSecondChanceOnHeadEnabled": true,
             "m_bHealSupplyUsageEnabled": false,
             "m_fMedicalKitMaxHealScaled": 1.0

--- a/docs/src/content/docs/components/medical.mdx
+++ b/docs/src/content/docs/components/medical.mdx
@@ -13,7 +13,7 @@ Note that ACE Medical currently only affects players, but not AI.
 
 ### Second Chance
 
-Second chance gets triggered when a player would have been killed without falling unconscious first. Instead of dying, the player will stay alive with 1 HP. On the other hand, they can only wake up from this state when epinephrine was administered (Automatic wake-up can be enabled by changing `m_fSecondChanceRegenScale` to a value above zero). Second chance is deactivated for headshots by default.
+Second chance gets triggered when a player would have been killed without falling unconscious first. Instead of dying, the player will stay alive with 1 HP. On the other hand, they can only wake up from this state when epinephrine is administered (Automatic wake-up can be enabled by changing `m_fSecondChanceRegenScale` to a value above zero). Second chance is deactivated for headshots by default.
 
 ## Settings
 


### PR DESCRIPTION
**When merged this pull request will:**
- Replace `m_fACE_Medical_SecondChanceFullRegenetationTimeS` with `m_fACE_Medical_SecondChanceRegenScale` to make it consistent with the existing vanilla attribute `m_fUnconsciousRegenerationScale`
- Fix calculation of regeneration rate
- Add `m_fSecondChanceRegenScale` to settings for changing the resilience regeneration rate and set default to `0`, such that they cannot wake up automatically without epinephrine.

