### PR TITLE
MagRepack - Fix `null` in target storage

### DIFF
--- a/addons/magrepack/scripts/Game/ACE_MagRepack/UI/Inventory/SCR_InventoryMenuUI.c
+++ b/addons/magrepack/scripts/Game/ACE_MagRepack/UI/Inventory/SCR_InventoryMenuUI.c
@@ -150,8 +150,8 @@ modded class SCR_InventoryMenuUI : ChimeraMenuBase
 		m_pCallBack.m_pStorageFrom = m_pSelectedSlotUI.GetStorageUI();
 		m_pCallBack.m_pStorageTo = m_pFocusedSlotUI.GetStorageUI();
 
-		BaseInventoryStorageComponent fromItemStorageComponent = m_pCallBack.m_pStorageFrom.GetCurrentNavigationStorage();
-		BaseInventoryStorageComponent toItemStorageComponent = m_pFocusedSlotUI.GetAsStorage();	
+		BaseInventoryStorageComponent fromItemStorageComponent = m_pCallBack.m_pStorageFrom.GetStorage();
+		BaseInventoryStorageComponent toItemStorageComponent = m_pCallBack.m_pStorageTo.GetStorage();
 		
 		SCR_PlayerController playerController = SCR_PlayerController.Cast(GetGame().GetPlayerController());
 		


### PR DESCRIPTION
**When merged this pull request will:**
- Change approach for getting storage, since `m_pFocusedSlotUI.GetAsStorage()` returns `null` on clients.
