### PR TITLE
Carrying - Handle simultaneously carry action

### DIFF
--- a/addons/carrying/Scripts/Game/ACE_Carrying/Character/SCR_CharacterControllerComponent.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/Character/SCR_CharacterControllerComponent.c
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------------------------
+modded class SCR_CharacterControllerComponent : CharacterControllerComponent
+{
+	[RplProp()]
+	protected bool m_bACE_Carrying_IsCarrier = false;
+	[RplProp()]
+	protected bool m_bACE_Carrying_IsCarried = false;
+	
+	//------------------------------------------------------------------------------------------------
+	void ACE_Carrying_SetIsCarrier(bool isCarrier)
+	{
+		m_bACE_Carrying_IsCarrier = isCarrier;
+		Replication.BumpMe();
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	bool ACE_Carrying_IsCarrier()
+	{
+		return m_bACE_Carrying_IsCarrier;
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	void ACE_Carrying_SetIsCarried(bool isCarried)
+	{
+		m_bACE_Carrying_IsCarried = isCarried;
+		Replication.BumpMe();
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	bool ACE_Carrying_IsCarried()
+	{
+		return m_bACE_Carrying_IsCarried;
+	}
+}

--- a/addons/carrying/Scripts/Game/ACE_Carrying/Entities/ACE_Carrying_HelperCompartment.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/Entities/ACE_Carrying_HelperCompartment.c
@@ -39,12 +39,14 @@ class ACE_Carrying_HelperCompartment : GenericEntity
 		if (!carrierController)
 			return;
 		
+		carrierController.ACE_Carrying_SetIsCarrier(true);
 		carrierController.m_OnLifeStateChanged.Insert(OnCarrierLifeStateChanged);
 		
 		SCR_CharacterControllerComponent carriedController = SCR_CharacterControllerComponent.Cast(carried.FindComponent(SCR_CharacterControllerComponent));
 		if (!carriedController)
 			return;
 		
+		carriedController.ACE_Carrying_SetIsCarried(true);
 		carriedController.m_OnLifeStateChanged.Insert(OnCarriedLifeStateChanged);
 
 		RplComponent carriedRpl = RplComponent.Cast(carried.FindComponent(RplComponent));
@@ -126,6 +128,7 @@ class ACE_Carrying_HelperCompartment : GenericEntity
 			if (!carrierController)
 				return;
 			
+			carrierController.ACE_Carrying_SetIsCarrier(false);
 			carrierController.m_OnLifeStateChanged.Remove(OnCarrierLifeStateChanged);
 		}
 
@@ -136,7 +139,8 @@ class ACE_Carrying_HelperCompartment : GenericEntity
 			SCR_CharacterControllerComponent carriedController = SCR_CharacterControllerComponent.Cast(m_pCarried.FindComponent(SCR_CharacterControllerComponent));
 			if (!carriedController)
 				return;
-		
+			
+			carriedController.ACE_Carrying_SetIsCarried(false);
 			carriedController.m_OnLifeStateChanged.Remove(OnCarriedLifeStateChanged);
 		}
 	}

--- a/addons/carrying/Scripts/Game/ACE_Carrying/Tools/ACE_Carrying_Tools.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/Tools/ACE_Carrying_Tools.c
@@ -45,7 +45,11 @@ class ACE_Carrying_Tools
 		if (!carrier)
 			return false;
 		
-		return GetHelperCompartmentFromCarrier(carrier);
+		SCR_CharacterControllerComponent controller = SCR_CharacterControllerComponent.Cast(carrier.FindComponent(SCR_CharacterControllerComponent));
+		if (!controller)
+			return false;
+		
+		return controller.ACE_Carrying_IsCarrier();
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -55,7 +59,11 @@ class ACE_Carrying_Tools
 		if (!carried)
 			return false;
 		
-		return GetHelperCompartmentFromCarried(carried);
+		SCR_CharacterControllerComponent controller = SCR_CharacterControllerComponent.Cast(carried.FindComponent(SCR_CharacterControllerComponent));
+		if (!controller)
+			return false;
+		
+		return controller.ACE_Carrying_IsCarried();
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
@@ -54,6 +54,11 @@ class ACE_Carrying_CarryUserAction : ScriptedUserAction
 	//------------------------------------------------------------------------------------------------
 	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)
 	{
+		// CanBePerformedScript runs on user's machine, so we have to
+		// double-check that the owner is in fact not already carried
+		if (ACE_Carrying_Tools.IsCarried(pOwnerEntity))
+			return;
+		
 		ACE_Carrying_Tools.Carry(pUserEntity, pOwnerEntity);
 	}
 	

--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
@@ -58,6 +58,6 @@ class ACE_Carrying_CarryUserAction : ScriptedUserAction
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	//! Methods are executed on the local player
+	//! Only run PerformAction on server
 	override bool CanBroadcastScript() { return false; };
 }

--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
@@ -54,6 +54,10 @@ class ACE_Carrying_CarryUserAction : ScriptedUserAction
 	//------------------------------------------------------------------------------------------------
 	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)
 	{
+		// Check on server if they are in faction not yet carried
+		if (ACE_Carrying_Tools.IsCarried(pOwnerEntity))
+			return;
+		
 		ACE_Carrying_Tools.Carry(pUserEntity, pOwnerEntity);
 	}
 	

--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
@@ -54,11 +54,6 @@ class ACE_Carrying_CarryUserAction : ScriptedUserAction
 	//------------------------------------------------------------------------------------------------
 	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)
 	{
-		// CanBePerformedScript runs on user's machine, so we have to
-		// double-check that the owner is in fact not already carried
-		if (ACE_Carrying_Tools.IsCarried(pOwnerEntity))
-			return;
-		
 		ACE_Carrying_Tools.Carry(pUserEntity, pOwnerEntity);
 	}
 	


### PR DESCRIPTION
**When merged this pull request will:**
- Use replicated variables on character controller for determining whether someone is carrier or carried
- Fix #98

**Background:**
- The previous approach determined whether someone is carrier or carried based on whether the helper compartment is part of the entity's hierarchy. However, this approach leads to race conditions, since it takes several frames for the carried player to move into the helper compartment and become a child of it.