### PR TITLE
Trenches - Fix orientation of built trenches

### DIFF
--- a/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingNetworkComponent.c
+++ b/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingNetworkComponent.c
@@ -22,7 +22,6 @@ modded class SCR_CampaignBuildingNetworkComponent : ScriptComponent
 		EntitySpawnParams params = new EntitySpawnParams();
 		params.TransformMode = ETransformMode.WORLD;
 		params.Transform = transform;
-		SCR_TerrainHelper.SnapAndOrientToTerrain(params.Transform);
 		// Forces to spawn as buildable
 		SCR_EditorLinkComponent.IgnoreSpawning(true);
 		


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #111

**Background:**
- Calling `SCR_TerrainHelper.SnapAndOrientToTerrain` twice on a transform messes up its orientation. It already gets called a first time in https://github.com/acemod/ACE-Anvil/blob/ece563d919d25a932f2d3cc5ffe38b1966674a85/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingGadgetToolComponent.c#L91
