### PR TITLE
Medical - Fix null pointer exception in SCR_HealSupportStationComponent DelayedInit method

### DIFF
--- a/addons/medical/scripts/Game/ACE_Medical/Components/SupportStation/SCR_HealSupportStationComponent.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/SupportStation/SCR_HealSupportStationComponent.c
@@ -7,7 +7,7 @@ modded class SCR_HealSupportStationComponent : SCR_BaseDamageHealSupportStationC
 	{
 		super.DelayedInit(owner);
 		
-		ACE_Medical_Settings settings =	ACE_SettingsHelperT<ACE_Medical_Settings>.GetModSettings();
+		ACE_Medical_Settings settings = ACE_SettingsHelperT<ACE_Medical_Settings>.GetModSettings();
 		if (!settings)
 			return;
 		
@@ -18,11 +18,11 @@ modded class SCR_HealSupportStationComponent : SCR_BaseDamageHealSupportStationC
 		resource.SetResourceTypeEnabled(settings.m_bHealSupplyUsageEnabled);
 		
 		// Set how much medical kits can heal
-		if (InventoryItemComponent.Cast(owner.FindComponent(InventoryItemComponent)) && m_fMaxHealScaled != settings.m_fMedicalKitMaxHealScaled)
+		if (owner && InventoryItemComponent.Cast(owner.FindComponent(InventoryItemComponent)) && m_fMaxHealScaled != settings.m_fMedicalKitMaxHealScaled)
 		{
 			m_fMaxHealScaled = settings.m_fMedicalKitMaxHealScaled;
 			Rpc(RpcDo_ACE_Medical_SetMaxHealScaledBroadcast, settings.m_fMedicalKitMaxHealScaled);
-		}	
+		}
 	}
 	
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**When merged this pull request will:**

- Handle cases where the owner variable could be null during the DelayedInit method
- Prevent virtual machine exceptions caused by the null owner pointer

![ArmaReforgerWorkbenchSteamDiag_CYP4siB6xu](https://github.com/user-attachments/assets/7b1b0232-015d-440e-a8d6-bbdfd7bc745c)
