### PR TITLE
Trenches - Add setting for making E-tool-placed fortifications slower to be built

### DIFF
--- a/addons/trenches/Configs/ACE/Settings.conf
+++ b/addons/trenches/Configs/ACE/Settings.conf
@@ -1,0 +1,6 @@
+ACE_SettingsConfig {
+ m_aInitialModSettings {
+  ACE_Treches_Settings "{62733434AE513E1A}" {
+  }
+ }
+}

--- a/addons/trenches/Configs/ACE/Settings.conf.meta
+++ b/addons/trenches/Configs/ACE/Settings.conf.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{A305FEB7400A2965}Configs/ACE/Settings.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingLayoutComponent.c
+++ b/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingLayoutComponent.c
@@ -24,4 +24,11 @@ modded class SCR_CampaignBuildingLayoutComponent : ScriptComponent
 		ent.AddChild(m_PreviewEntity, -1, EAddChildFlags.RECALC_LOCAL_TRANSFORM);
 		m_PreviewEntity.Update();
 	}
+	
+	//------------------------------------------------------------------------------------------------
+	void ACE_Trenches_SetToBuildValue(int value)
+	{
+		m_iToBuildValue = value;
+		Replication.BumpMe();
+	}
 }

--- a/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingNetworkComponent.c
+++ b/addons/trenches/scripts/Game/ACE_Trenches/Building/SCR_CampaignBuildingNetworkComponent.c
@@ -67,6 +67,16 @@ modded class SCR_CampaignBuildingNetworkComponent : ScriptComponent
 			return;
 		
 		compositionComponent.SetBuilderId(playerController.GetPlayerId());
+		
+		SCR_CampaignBuildingLayoutComponent layoutComponent = SCR_CampaignBuildingLayoutComponent.Cast(asset.GetChildren().FindComponent(SCR_CampaignBuildingLayoutComponent));
+		if (!layoutComponent)
+			return;
+		
+		ACE_Treches_Settings settings = ACE_SettingsHelperT<ACE_Treches_Settings>.GetModSettings();
+		if (!settings)
+			return;
+		
+		layoutComponent.ACE_Trenches_SetToBuildValue(settings.m_fBuildTimeScale * layoutComponent.GetToBuildValue());
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/addons/trenches/scripts/Game/ACE_Trenches/Mission/ACE_MissionHeaderSettings.c
+++ b/addons/trenches/scripts/Game/ACE_Trenches/Mission/ACE_MissionHeaderSettings.c
@@ -1,0 +1,16 @@
+//------------------------------------------------------------------------------------------------
+//! Add mod settings to mission header
+[BaseContainerProps()]
+modded class ACE_MissionHeaderSettings
+{
+	[Attribute()]
+	protected ref ACE_Treches_Settings m_ACE_Treches_Settings;
+	
+	//------------------------------------------------------------------------------------------------
+	//! Applies settings from mission header to config
+	override void ApplyToSettingsConfig(notnull ACE_SettingsConfig config)
+	{
+		if (m_ACE_Treches_Settings)
+			config.SetModSettings(m_ACE_Treches_Settings);
+	}
+}

--- a/addons/trenches/scripts/Game/ACE_Trenches/Settings/ACE_Treches_Settings.c
+++ b/addons/trenches/scripts/Game/ACE_Trenches/Settings/ACE_Treches_Settings.c
@@ -1,0 +1,8 @@
+//------------------------------------------------------------------------------------------------
+//! Settings for a mod
+[BaseContainerProps()]
+class ACE_Treches_Settings : ACE_ModSettings
+{
+	[Attribute(defvalue: "2", desc: "How much more time it takes to build structures placed with the E-tool [s]")]
+	float m_fBuildTimeScale;
+}


### PR DESCRIPTION
**When merged this pull request will:**
- Add `m_fBuildTimeScale` setting for making E-tool-placed fortifications slower to build (Default value: `2`)
