### PR TITLE
Fix mission header settings from different components override each other

### DIFF
--- a/addons/finger/scripts/Game/ACE_Finger/Mission/ACE_MissionHeaderSettings.c
+++ b/addons/finger/scripts/Game/ACE_Finger/Mission/ACE_MissionHeaderSettings.c
@@ -10,6 +10,8 @@ modded class ACE_MissionHeaderSettings
 	//! Applies settings from mission header to config
 	override void ApplyToSettingsConfig(notnull ACE_SettingsConfig config)
 	{
+		super.ApplyToSettingsConfig(config);
+		
 		if (m_ACE_Finger_Settings)
 			config.SetModSettings(m_ACE_Finger_Settings);
 	}

--- a/addons/medical/scripts/Game/ACE_Medical/Mission/ACE_MissionHeaderSettings.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Mission/ACE_MissionHeaderSettings.c
@@ -10,6 +10,8 @@ modded class ACE_MissionHeaderSettings
 	//! Applies settings from mission header to config
 	override void ApplyToSettingsConfig(notnull ACE_SettingsConfig config)
 	{
+		super.ApplyToSettingsConfig(config);
+		
 		if (m_ACE_Medical_Settings)
 			config.SetModSettings(m_ACE_Medical_Settings);
 	}


### PR DESCRIPTION
**When merged this pull request will:**
- Call `super` for all overrides of `ACE_MissionHeaderSettings.ApplyToSettingsConfig`

