### PR TITLE
Fixes for Reforger `1.3.0.18`

### DIFF
--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/ACE_Carrying_CarryUserAction.c
@@ -44,7 +44,7 @@ class ACE_Carrying_CarryUserAction : ScriptedUserAction
 		// Trying to carry while unit is ragdolling will break things
 		if (ownerChar.GetAnimationComponent().IsRagdollActive())
 		{
-			SetCannotPerformReason(ActionMenuFailReason.DEFAULT);
+			SetCannotPerformReason("#AR-UserActionUnavailable");
 			return false;
 		}
 

--- a/addons/core/scripts/Game/ACE_Core/UserActions/ACE_GadgetUserAction.c
+++ b/addons/core/scripts/Game/ACE_Core/UserActions/ACE_GadgetUserAction.c
@@ -59,7 +59,7 @@ class ACE_GadgetUserAction : ScriptedUserAction
 			int itemActionId = pAnimationComponent.BindCommand("CMD_Item_Action");
 			CharacterCommandHandlerComponent cmdHandler = CharacterCommandHandlerComponent.Cast(pAnimationComponent.GetCommandHandler());
 			if (cmdHandler)
-				cmdHandler.FinishItemUse();
+				cmdHandler.FinishItemUse(true);
 		}
 	}
 	
@@ -79,7 +79,7 @@ class ACE_GadgetUserAction : ScriptedUserAction
 		{
 			CharacterAnimationComponent pAnimationComponent = charController.GetAnimationComponent();
 			CharacterCommandHandlerComponent cmdHandler = CharacterCommandHandlerComponent.Cast(pAnimationComponent.GetCommandHandler());
-			cmdHandler.FinishItemUse();
+			cmdHandler.FinishItemUse(true);
 		}
 	}
 	

--- a/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/Damage/SCR_CharacterDamageManagerComponent.c
@@ -29,9 +29,9 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 	
 	//-----------------------------------------------------------------------------------------------------------
 	//! Initialize member variables
-	override void OnInit(IEntity owner)
+	override void OnPostInit(IEntity owner)
 	{
-		super.OnInit(owner);
+		super.OnPostInit(owner);
 		
 		m_pACE_Medical_HealthHitZone = GetHitZoneByName("Health");
 		if (!m_pACE_Medical_HealthHitZone)

--- a/addons/medical/scripts/Game/ACE_Medical/Components/Gadgets/ACE_Medical_ConsumableEpinephrine.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/Gadgets/ACE_Medical_ConsumableEpinephrine.c
@@ -19,7 +19,7 @@ class ACE_Medical_ConsumableEpinephrine : SCR_ConsumableEffectHealthItems
 			return false;
 
 		// Check if epinephrine is in the system already
-		array<ref PersistentDamageEffect> effects = damageManager.GetAllPersistentEffectsOfType(ACE_Medical_EpinephrineDamageEffect);
+		array<ref SCR_PersistentDamageEffect> effects = damageManager.GetAllPersistentEffectsOfType(ACE_Medical_EpinephrineDamageEffect);
 		if (!effects.IsEmpty())
 		{
 			failReason = SCR_EConsumableFailReason.ALREADY_APPLIED;

--- a/addons/medical/scripts/Game/ACE_Medical/Components/Gadgets/ACE_Medical_ConsumableMorphine.c
+++ b/addons/medical/scripts/Game/ACE_Medical/Components/Gadgets/ACE_Medical_ConsumableMorphine.c
@@ -21,7 +21,7 @@ class ACE_Medical_ConsumableMorphine : SCR_ConsumableEffectHealthItems
 			return false;
 		
 		// Check if morphine is in the system already
-		array<ref PersistentDamageEffect> effects = damageManager.GetAllPersistentEffectsOfType(ACE_Medical_MorphineDamageEffect);
+		array<ref SCR_PersistentDamageEffect> effects = damageManager.GetAllPersistentEffectsOfType(ACE_Medical_MorphineDamageEffect);
 		if (!effects.IsEmpty())
 		{
 			failReason = SCR_EConsumableFailReason.ALREADY_APPLIED;


### PR DESCRIPTION
**When merged this pull request will account for the following changes:**
- New signature of `FinishItemUse`
- `ActionMenuFailReason` no longer exists
- `OnInit` got replaced with `OnPostInit` in `SCR_CharacterDamageManagerComponent`
- `GetAllPersistentEffectsOfType` returns `array<ref SCR_PersistentDamageEffect>` instead of `array<ref PersistentDamageEffect>`

**Affected components:**
- Carrying
- Core
- Medical