### PR TITLE
Fix docs for float-based mission header settings

### DIFF
--- a/docs/src/content/docs/components/finger.mdx
+++ b/docs/src/content/docs/components/finger.mdx
@@ -21,22 +21,23 @@ Allows players to point in a direction with their fingers, when they do so peopl
 
 Certain aspects of this mod can be configured in the mission header section of a server config file. An overview of available fields is given below in the table:
 
-| Field                   | Type  | Default | Description                                                                                    |
-| ----------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------- |
-| m_fMaxPointingDistanceM | float | 1000    | Maximum pointing distance in meters.                                                           |
-| m_bCanPingAttach        | bool* | true    | Whether the ping can attach to entities.                                                       |
-| m_fPingRangeM           | float | 10      | Range of the ping in meters. Only players in range will see it. Anyone can see it if negative. |
+| Field                   | Type    | Default | Description                                                                                    |
+| ----------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------- |
+| m_fMaxPointingDistanceM | float** | 1000.0  | Maximum pointing distance in meters.                                                           |
+| m_bCanPingAttach        | bool*   | true    | Whether the ping can attach to entities.                                                       |
+| m_fPingRangeM           | float** | 10.0    | Range of the ping in meters. Only players in range will see it. Anyone can see it if negative. |
 
-\* Note that bool has to be provided as integer in the config: 1 (true) or 0 (false).
+\* Note that bool has to be provided as integer in the config: 1 (true) or 0 (false).<br>
+\*\* Note that floats need a decimal point to get properly read.
 
 Example for the `missionHeader` in a server config:
 ```
 "missionHeader": {
     "m_ACE_Settings": {
         "m_ACE_Finger_Settings": {
-            "m_fMaxPointingDistanceM": 1000,
+            "m_fMaxPointingDistanceM": 1000.0,
             "m_bCanPingAttach": 1,
-            "m_fPingRangeM": 10
+            "m_fPingRangeM": 10.0
         }
     }
 }

--- a/docs/src/content/docs/components/medical.mdx
+++ b/docs/src/content/docs/components/medical.mdx
@@ -19,14 +19,15 @@ Second chance gets triggered when a player would have been killed without fallin
 
 Certain aspects of the medical system can be configured in the mission header section of a server config file. An overview of available fields is given below in the table:
 
-| Field                        | Type  | Default | Description                                                                                          |
-| ---------------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------- |
-| m_fSecondChanceRegenScale      | float | 0.0     | Scales the unconsciousness recovery rate when second chance was triggered. The default recovery rate (full recovery in 20 s) will be multiplied by this factor. Note that recovery only starts 10 s after the last incoming damage. |
-| m_bSecondChanceOnHeadEnabled | bool* | false   | Enables second chance on headshots.                                                                  |
-| m_bHealSupplyUsageEnabled    | bool* | true    | Healing consumes supplies when enabled. Ignored when global supply usage is disabled.                |
-| m_fMedicalKitMaxHealScaled   | float | 0.5     | Maximum scaled health (from 0.0 to 1.0) that a medical kit can heal outside of medical facilities.   |
+| Field                        | Type    | Default | Description                                                                                          |
+| ---------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| m_fSecondChanceRegenScale    | float** | 0.0     | Scales the unconsciousness recovery rate when second chance was triggered. The default recovery rate (full recovery in 20 s) will be multiplied by this factor. Note that recovery only starts 10 s after the last incoming damage. |
+| m_bSecondChanceOnHeadEnabled | bool*   | false   | Enables second chance on headshots.                                                                  |
+| m_bHealSupplyUsageEnabled    | bool*   | true    | Healing consumes supplies when enabled. Ignored when global supply usage is disabled.                |
+| m_fMedicalKitMaxHealScaled   | float** | 0.5     | Maximum scaled health (from 0.0 to 1.0) that a medical kit can heal outside of medical facilities.   |
 
-\* Note that bool has to be provided as integer in the config: 1 (true) or 0 (false).
+\* bool has to be provided as integer in the config: 1 (true) or 0 (false).<br>
+\*\* float need a decimal point to get properly read.
 
 Example for the `missionHeader` in a server config:
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- Add decimal points to float-based example configs
- Add note that decimal points are needed