### PR TITLE
Carrying - Fix unconscious AI breaks when unloading from a vehicle

### DIFF
--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/SCR_RemoveCasualtyUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/SCR_RemoveCasualtyUserAction.c
@@ -24,6 +24,10 @@ modded class SCR_RemoveCasualtyUserAction : SCR_CompartmentUserAction
 		if (!userCharController)
 			return;
 		
+		// We just eject AI for now. Trying to carrying them immediatly breaks their animation
+		if (!EntityUtils.IsPlayer(casualtyChar))
+			return;
+		
 		string cannotPerformReason;
 		if (userCharController.ACE_Carrying_CanCarryCasualty(casualtyChar, cannotPerformReason))
 			userCharController.ACE_Carrying_CarryCasualty(casualtyChar);


### PR DESCRIPTION
**When merged this pull request will:**
- Eject unconscious AI from vehicles without initiating carrying when unloading from a vehicle.
