### PR TITLE
Core - Add basics for ACE radial menus

### DIFF
--- a/addons/core/Prefabs/Characters/Core/DefaultPlayerController.et
+++ b/addons/core/Prefabs/Characters/Core/DefaultPlayerController.et
@@ -1,0 +1,7 @@
+SCR_PlayerController {
+ ID "1A9BA6BEFA06E3B1"
+ components {
+  ACE_RadialMenuComponent "{654944904311E33E}" {
+  }
+ }
+}

--- a/addons/core/Prefabs/Characters/Core/DefaultPlayerController.et.meta
+++ b/addons/core/Prefabs/Characters/Core/DefaultPlayerController.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{6E2BB64764E3BE9B}Prefabs/Characters/Core/DefaultPlayerController.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/core/scripts/Game/ACE_Core/Global/Sorting/ACE_CompareItemName.c
+++ b/addons/core/scripts/Game/ACE_Core/Global/Sorting/ACE_CompareItemName.c
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------------------------------
+class ACE_CompareItemName : SCR_SortCompare<IEntity>
+{
+	//---------------------------------------------------------------------------------------------------
+	override static int Compare(IEntity left, IEntity right)
+	{
+		if (GetName(left).Compare(GetName(right)) == -1)
+			return 1;
+		else
+			return 0;
+	}
+	
+	//---------------------------------------------------------------------------------------------------
+	protected static string GetName(IEntity item)
+	{
+		InventoryItemComponent itemComponent = InventoryItemComponent.Cast(item.FindComponent(InventoryItemComponent));
+		if (!itemComponent)
+			return "";
+
+		UIInfo uiInfo = itemComponent.GetUIInfo();
+		if (!uiInfo)
+			return "";
+		
+		return uiInfo.GetName();
+	}
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectItemRadialMenuCategoryEntry.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectItemRadialMenuCategoryEntry.c
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------------------------
+//! Creates radial submenu based on items of the local player matching m_pItemSearchPredicate
+[BaseContainerProps(configRoot: true), SCR_BaseContainerCustomTitleUIInfo("Name")]
+class ACE_SelectItemRadialMenuCategoryEntry : ACE_SelectionMenuCategoryEntry
+{
+	[Attribute(desc: "Perdicate that items should match")]
+	protected ref ACE_InventorySearchPredicate m_pItemSearchPredicate;
+	
+	//------------------------------------------------------------------------------------------------
+	override protected void OnPerform()
+	{
+		m_aEntries.Clear();
+		
+		IEntity char = SCR_PlayerController.GetLocalControlledEntity();
+		if (!char)
+			return;
+		
+		SCR_InventoryStorageManagerComponent storageManager = SCR_InventoryStorageManagerComponent.Cast(char.FindComponent(SCR_InventoryStorageManagerComponent));		
+		if (!storageManager)
+			return;
+		
+		array<IEntity> items = {};
+		storageManager.FindItems(items, m_pItemSearchPredicate);
+		SCR_Sorting<IEntity, ACE_CompareItemName>.HeapSort(items, false);
+		
+		// Make sure we only add each
+		set<EntityPrefabData> uniquePrefabDataSet = new set<EntityPrefabData>();
+		
+		foreach (IEntity item : items)
+		{
+			EntityPrefabData prefabData = item.GetPrefabData();
+			if (!prefabData)
+				continue;
+			
+			if (uniquePrefabDataSet.Find(prefabData) >= 0)
+				continue;
+			
+			m_aEntries.Insert(new ACE_SelectItemRadialMenuEntry(item));
+			uniquePrefabDataSet.Insert(prefabData);
+		}
+	}
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectItemRadialMenuEntry.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectItemRadialMenuEntry.c
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------------------------
+//! Creates radial menu entry for the item passed to constructor
+[BaseContainerProps(configRoot: true), SCR_BaseContainerCustomTitleUIInfo("Name")]
+class ACE_SelectItemRadialMenuEntry : ACE_SelectionMenuEntry
+{
+	protected IEntity m_pItem;
+	protected const ResourceName LAYOUT_ITEM = "{93472DECDA62C46F}UI/layouts/Common/RadialMenu/SelectionMenuEntryPreview.layout";
+	
+	//------------------------------------------------------------------------------------------------
+	override protected void OnPerform()
+	{
+		IEntity char = SCR_PlayerController.GetLocalControlledEntity();
+		if (!char)
+			return;
+		
+		SCR_CharacterInventoryStorageComponent storage = SCR_CharacterInventoryStorageComponent.Cast(char.FindComponent(SCR_CharacterInventoryStorageComponent));		
+		if (m_pItem && storage && storage.CanUseItem(m_pItem))
+			storage.UseItem(m_pItem);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	override void SetEntryComponent(SCR_SelectionMenuEntryComponent entryComponent)
+	{
+		super.SetEntryComponent(entryComponent);
+		
+		SCR_SelectionMenuEntryPreviewComponent entryPreview = SCR_SelectionMenuEntryPreviewComponent.Cast(entryComponent);
+		if (entryPreview)
+			entryPreview.SetPreviewItem(m_pItem);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	void ACE_SelectItemRadialMenuEntry(IEntity item)
+	{
+		SetCustomLayout(LAYOUT_ITEM);
+		
+		InventoryItemComponent itemComponent = InventoryItemComponent.Cast(item.FindComponent(InventoryItemComponent));
+		if (!itemComponent)
+			return;
+
+		UIInfo uiInfo = itemComponent.GetUIInfo();
+		if (uiInfo)
+			SetName(uiInfo.GetName());
+		
+		m_pItem = item;
+	}
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectionMenuCategoryEntry.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectionMenuCategoryEntry.c
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------
+[BaseContainerProps(configRoot: true), SCR_BaseContainerCustomTitleUIInfo("Name")]
+class ACE_SelectionMenuCategoryEntry : SCR_SelectionMenuCategoryEntry
+{
+	//------------------------------------------------------------------------------------------------
+	bool CanBePerformed()
+	{
+		return true;
+	}
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectionMenuEntry.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/ACE_SelectionMenuEntry.c
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------
+[BaseContainerProps(configRoot: true), SCR_BaseContainerCustomTitleUIInfo("Name")]
+class ACE_SelectionMenuEntry : SCR_SelectionMenuEntry
+{
+	//------------------------------------------------------------------------------------------------
+	bool CanBePerformed()
+	{
+		return true;
+	}
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/RadialMenu/ACE_RadialMenuComponent.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/RadialMenu/ACE_RadialMenuComponent.c
@@ -1,0 +1,12 @@
+//------------------------------------------------------------------------------------------------
+class ACE_RadialMenuComponentClass : ScriptComponentClass
+{
+}
+
+//------------------------------------------------------------------------------------------------
+//! Component on player controller for registering radial menus
+class ACE_RadialMenuComponent : ScriptComponent
+{
+	[Attribute()]
+	protected ref array<ref SCR_RadialMenuController> m_aRadialMenuControllers;
+}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/RadialMenu/ACE_RadialMenuController.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/SelectionMenu/RadialMenu/ACE_RadialMenuController.c
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------------------------
+//! Same as SCR_RadialMenuController, but automatically adds entries in m_Data to radial menu
+[BaseContainerProps(configRoot: true)]
+class ACE_RadialMenuController : SCR_RadialMenuController
+{
+	//------------------------------------------------------------------------------------------------
+	override void Control(IEntity owner, SCR_RadialMenu radialMenu = null)
+	{
+		super.Control(owner, radialMenu);
+		UpdateMenuData();
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	override void OnInputOpen()
+	{
+		super.OnInputOpen();
+		DisableUnperformableEntries(m_RadialMenu.GetEntries());
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	protected void DisableUnperformableEntries(array<ref SCR_SelectionMenuEntry> entries)
+	{
+		foreach (SCR_SelectionMenuEntry entry : entries)
+		{
+			ACE_SelectionMenuEntry aceEntry = ACE_SelectionMenuEntry.Cast(entry);
+			if (aceEntry)
+				aceEntry.Enable(aceEntry.CanBePerformed());
+			
+			SCR_SelectionMenuCategoryEntry categoryEntry = SCR_SelectionMenuCategoryEntry.Cast(entry);
+			if (categoryEntry)
+				DisableUnperformableEntries(categoryEntry.GetEntries());
+			
+			ACE_SelectionMenuCategoryEntry aceCategoryEntry = ACE_SelectionMenuCategoryEntry.Cast(entry);
+			if (aceCategoryEntry)
+				aceCategoryEntry.Enable(aceCategoryEntry.CanBePerformed());
+		}
+	}
+}

--- a/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_CommonTypeWhitelistItemPredicate.c
+++ b/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_CommonTypeWhitelistItemPredicate.c
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------------------------
+//! Match items based on a whitelist of ECommonItemType
+[BaseContainerProps()]
+class ACE_CommonTypeWhitelistItemPredicate : ACE_InventorySearchPredicate
+{
+	[Attribute(defvalue: "", uiwidget: UIWidgets.SearchComboBox, enums: ParamEnumArray.FromEnum(ECommonItemType))]
+	ref array<ECommonItemType> m_aWhitelist;
+
+	//------------------------------------------------------------------------------------------------
+	void ACE_CommonTypeWhitelistItemPredicate()
+	{
+		QueryAttributeTypes.Insert(SCR_ItemOfInterestAttribute);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	override protected bool IsMatch(BaseInventoryStorageComponent storage, IEntity item, array<GenericComponent> queriedComponents, array<BaseItemAttributeData> queriedAttributes)
+	{
+		SCR_ItemOfInterestAttribute optionalAttribute = SCR_ItemOfInterestAttribute.Cast(queriedAttributes[0]);
+		return m_aWhitelist.Find(optionalAttribute.GetInterestType()) >= 0;
+	}
+}

--- a/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_HealItemPredicate.c
+++ b/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_HealItemPredicate.c
@@ -1,0 +1,11 @@
+//------------------------------------------------------------------------------------------------
+//! Match items with a SCR_HealSupportStationComponent
+[BaseContainerProps()]
+class ACE_HealItemPredicate : ACE_InventorySearchPredicate
+{
+	//------------------------------------------------------------------------------------------------
+	void ACE_HealItemPredicate()
+	{
+		QueryComponentTypes.Insert(SCR_HealSupportStationComponent);
+	}
+}

--- a/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_InventorySearchPredicate.c
+++ b/addons/core/scripts/GameCode/ACE_Core/Components/InventorySystem/InventoryTask/ACE_InventorySearchPredicate.c
@@ -1,0 +1,6 @@
+//------------------------------------------------------------------------------------------------
+//! Same as InventorySearchPredicate, but can be used as attribute
+[BaseContainerProps()]
+class ACE_InventorySearchPredicate : InventorySearchPredicate
+{
+}


### PR DESCRIPTION
**When merged this pull request will:**
- Add `ACE_RadialMenuComponent ` on player controller as container for ACE-based radial menus.
- Add `ACE_SelectionMenuEntry` and `ACE_SelectionMenuCategoryEntry` that extend the vanilla entries with `CanBePerformed` method.
- Add `ACE_SelectItemRadialMenuEntry` and `ACE_SelectItemRadialMenuCategoryEntry` for building inventory item-based entries.