### PR TITLE
Captives - Clean-up helper compartment init

### DIFF
--- a/addons/captives/scripts/Game/ACE_Captives/Helpers/ACE_Captives_SurrenderHelperCompartment.c
+++ b/addons/captives/scripts/Game/ACE_Captives/Helpers/ACE_Captives_SurrenderHelperCompartment.c
@@ -13,7 +13,7 @@ class ACE_Captives_SurrenderHelperCompartment : ACE_AnimationHelperCompartment
 	{
 		super.Init(performer);
 		
-		SCR_CharacterControllerComponent charCtrl = SCR_CharacterControllerComponent.Cast(m_pPerformer.FindComponent(SCR_CharacterControllerComponent));
+		SCR_CharacterControllerComponent charCtrl = SCR_CharacterControllerComponent.Cast(performer.FindComponent(SCR_CharacterControllerComponent));
 		if (charCtrl)
 			charCtrl.ACE_Captives_SetHasSurrendered(true);
 		

--- a/addons/core/scripts/Game/ACE_Core/Helpers/ACE_AnimationHelperCompartment.c
+++ b/addons/core/scripts/Game/ACE_Core/Helpers/ACE_AnimationHelperCompartment.c
@@ -30,7 +30,7 @@ class ACE_AnimationHelperCompartment : GenericEntity
 			compartmentAccess.GetOnCompartmentEntered().Insert(OnCompartmentEntered);
 		
 		m_pPerformer = performer;
-		m_iPerformerID = Replication.FindItemId(m_pPerformer);
+		m_iPerformerID = Replication.FindItemId(performer);
 		OnPerformerChanged();
 		Replication.BumpMe();
 	}


### PR DESCRIPTION
**When merged this pull request will:**
- Use `performer` instead of `m_pPerformer` in `Init`

