### PR TITLE
Tools - Add make.py for validating, packing and publishing

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -10,7 +10,7 @@ import enum
 # GLOBALS
 PROJECT_DIR_PATH = Path(__file__).resolve().parent.parent
 PROJECT_ADDONS_DIRS = [PROJECT_DIR_PATH / 'addons', PROJECT_DIR_PATH / 'optionals']
-BLACKLISTED_ADDON_IDS = ['ACE_Medical_Core', 'ACE_Medical_Hitzones', 'ACE_Medical_Circulation', 'ACE_Explosives']
+BLACKLISTED_ADDON_IDS = []
 WORKBENCH_EXTRA_ARGS = ['-enableWARP', '-noThrow', '-noSound', '-scriptAuthorizeAll', '-silentCrashReport', '-VMErrorMode', 'fatal']
 LOGGER_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `make.py` with following commands:
  - `validate`: Validates scripts of addons and raises exception on failure
  - `pack`: Packs addons
  - `publish`: Packs and publishes update for addons. The target version will be the same as the latest tag. The change notes will be set to the corresponding GitHub release URL. Publishing new addons is not possible and has to be done manually instead.

  All commands will be applied to the whole repo, unless a specific addon is selected with `--just` option.