### PR TITLE
Medical Circulation - Fix players teleporting after CPR

### DIFF
--- a/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Helpers/ACE_Medical_CPRHelperCompartment.c
+++ b/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Helpers/ACE_Medical_CPRHelperCompartment.c
@@ -21,5 +21,7 @@ class ACE_Medical_CPRHelperCompartment : ACE_AnimationHelperCompartment
 	{
 		if (m_pPatientVitals)
 			m_pPatientVitals.SetIsCPRPerformed(false);
+		
+		super.OnCompartmentLeft();
 	}
 }

--- a/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Helpers/ACE_Medical_CPRHelperCompartment.c
+++ b/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Helpers/ACE_Medical_CPRHelperCompartment.c
@@ -19,9 +19,9 @@ class ACE_Medical_CPRHelperCompartment : ACE_AnimationHelperCompartment
 	//------------------------------------------------------------------------------------------------
 	override void OnCompartmentLeft()
 	{
+		super.OnCompartmentLeft();
+		
 		if (m_pPatientVitals)
 			m_pPatientVitals.SetIsCPRPerformed(false);
-		
-		super.OnCompartmentLeft();
 	}
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Stop players teleporting to locations where they performed CPR before.

**Requires:**
- #239 