### PR TITLE
Medical - Fix: only show CPR and Check Vitals actions for INCAPACITATED patients

### DIFF
--- a/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/UserActions/ACE_Medical_CPRUserAction.c
+++ b/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/UserActions/ACE_Medical_CPRUserAction.c
@@ -38,7 +38,7 @@ class ACE_Medical_CPRUserAction : ScriptedUserAction
 		if (!ownerController)
 			return false;
 		
-		if (!ownerController.IsUnconscious())
+		if (ownerController.GetLifeState() != ECharacterLifeState.INCAPACITATED)
 			return false;
 		
 		CharacterAnimationComponent ownerAnimation = ownerChar.GetAnimationComponent();

--- a/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/UserActions/ACE_Medical_CheckVitalsUserAction.c
+++ b/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/UserActions/ACE_Medical_CheckVitalsUserAction.c
@@ -35,7 +35,7 @@ class ACE_Medical_CheckVitalsUserAction : ScriptedUserAction
 		if (!ownerController)
 			return false;
 		
-		if (!ownerController.IsUnconscious())
+		if (ownerController.GetLifeState() != ECharacterLifeState.INCAPACITATED)
 			return false;
 		
 		CharacterAnimationComponent ownerAnimation = m_pOwner.GetAnimationComponent();


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent "Check Vitals" and "Perform CPR" actions from appearing on dead patients.
- Add an explicit `ECharacterLifeState.INCAPACITATED` check to `ACE_Medical_CPRUserAction`.
- Add an explicit `ECharacterLifeState.INCAPACITATED` check to `ACE_Medical_CheckVitalsUserAction`.