### PR TITLE
Medical Circulation - Fix reset vitals

### DIFF
--- a/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Components/ACE_Medical_VitalsComponent.c
+++ b/addons/medical_circulation/scripts/Game/ACE_Medical_Circulation/Components/ACE_Medical_VitalsComponent.c
@@ -218,25 +218,23 @@ class ACE_Medical_VitalsComponent : ScriptComponent
 	//! Resets vitals to defaults
 	void Reset()
 	{
-		// direct member assignment avoids Replication.BumpMe() calls during EOnInit,
-		// to prevent premature replication that can cause init order issues
 		ACE_Medical_Circulation_Settings settings = ACE_SettingsHelperT<ACE_Medical_Circulation_Settings>.GetModSettings();
 		if (settings)
 		{
-			m_fHeartRateBPM = settings.m_fDefaultHeartRateBPM;
-			m_fCardiacOutput = settings.m_fDefaultHeartRateBPM * settings.m_fDefaultStrokeVolumeML;
-			m_fSystemicVascularResistance = settings.m_fDefaultSystemicVascularResistance;
-			m_fMeanArterialPressureKPA = settings.m_fDefaultMeanArterialPressureKPA;
-			m_fPulsePressureKPA = settings.m_fDefaultPulsePressureKPA;
+			SetHeartRate(settings.m_fDefaultHeartRateBPM);
+			SetCardiacOutput(settings.m_fDefaultHeartRateBPM * settings.m_fDefaultStrokeVolumeML);
+			SetSystemicVascularResistance(settings.m_fDefaultSystemicVascularResistance);
+			SetMeanArterialPressure(settings.m_fDefaultMeanArterialPressureKPA);
+			SetPulsePressure(settings.m_fDefaultPulsePressureKPA);
 		}
 		
-		m_fHeartRateMedicationAdjustment = 0;
-		m_fSystemicVascularResistanceMedicationAdjustment = 0;
-		m_fReviveSuccessCheckTimerScale = 1;
+		SetHeartRateMedicationAdjustment(0);
+		SetSystemicVascularResistenceMedicationAdjustment(0);
+		SetReviveSuccessCheckTimerScale(1);
 		
-		m_bWasRevived = false;
+		ClearReviveHistory();
 		
-		m_eVitalStateID = ACE_Medical_EVitalStateID.STABLE;
+		SetVitalStateID(ACE_Medical_EVitalStateID.STABLE);
 	}
 	
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a bug where `VitalsComponent.Reset()` was incomplete, leading to a potentially inconsistent state on initialization or reset.

**When merged this pull request will:**
* Fix the `Reset()` function to correctly set *all* default vitals (MAP, CO, SVR, PP), not just HeartRate.
* Ensure that medication adjustments and all status flags (CPR, Revive History, Timers) are also cleared.
* Optimize the `Reset()` function to use direct member assignment instead of Setters, preventing unnecessary replication calls during `EOnInit`.

**Requires:**
- #239 