### PR TITLE
Medical - Add configurable armor pain system

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,7 +13,6 @@ veteran29
 # CONTRIBUTORS
 AkiKay
 Badger 2-3
-Fedora12 <monn45888@gmail.com>
 Glowbal
 gnif <geoff@hostfission.com>
 Jonpas <jonpas33@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ veteran29
 # CONTRIBUTORS
 AkiKay
 Badger 2-3
+Fedora12 <monn45888@gmail.com>
 Glowbal
 gnif <geoff@hostfission.com>
 Jonpas <jonpas33@gmail.com>

--- a/addons/medical_core/scripts/Game/ACE_Medical_Pain/Components/Damage/SCR_CharacterDamageManagerComponent.c
+++ b/addons/medical_core/scripts/Game/ACE_Medical_Pain/Components/Damage/SCR_CharacterDamageManagerComponent.c
@@ -2,9 +2,15 @@
 modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 {
 	protected ACE_Medical_PainHitZone m_ACE_Medical_PainHitZone;
-	
+
 	[RplProp(condition: RplCondition.OwnerOnly)]
 	protected float m_fACE_Medical_PainSuppression = 0;
+
+	[Attribute(defvalue: "0.25", uiwidget: UIWidgets.Slider, desc: "Percentage of armor damage that gets converted to pain", params: "0 1 0.01")]
+	protected float m_fACE_Medical_ArmorPainMultiplier;
+
+	[Attribute(defvalue: "10", uiwidget: UIWidgets.Slider, desc: "Minimum armor damage required to cause pain", params: "0 50 1")]
+	protected float m_fACE_Medical_ArmorPainThreshold;
 	
 	//-----------------------------------------------------------------------------------------------------------
 	//! Called by ACE_Medical_PainHitZone.OnInit to initialize the hit zone
@@ -58,5 +64,36 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 	float ACE_Medical_GetPainSuppression()
 	{
 		return m_fACE_Medical_PainSuppression;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Add pain when armor blocks damage
+	//! Behavior:
+	//! - Small impacts below threshold are ignored
+	//! - First significant impact sets character to moderate pain state
+	//! - Subsequent hits when already beyond moderate don't add more pain
+	override void ArmorHitEventDamage(EDamageType type, float damage, IEntity instigator)
+	{
+		super.ArmorHitEventDamage(type, damage, instigator);
+
+		if (!m_ACE_Medical_PainHitZone)
+			return;
+
+		if (damage < m_fACE_Medical_ArmorPainThreshold)
+			return;
+
+		// If already in pain (beyond moderate), don't add more
+		if (ACE_Medical_IsInPain())
+			return;
+
+		// Not in pain yet - apply pain to reach moderate threshold
+		float painDamage = damage * m_fACE_Medical_ArmorPainMultiplier;
+
+		float moderateThreshold = m_ACE_Medical_PainHitZone.GetDamageStateThreshold(ECharacterHealthState.MODERATE);
+		float currentHealth = m_ACE_Medical_PainHitZone.GetHealthScaled();
+		float minDamageForPain = (currentHealth - moderateThreshold) * m_ACE_Medical_PainHitZone.GetMaxHealth();
+
+		painDamage = Math.Max(painDamage, minDamageForPain);
+		m_ACE_Medical_PainHitZone.HandleDamage(painDamage, EDamageType.TRUE, instigator);
 	}
 }

--- a/addons/medical_core/scripts/Game/ACE_Medical_Pain/Components/Damage/SCR_CharacterDamageManagerComponent.c
+++ b/addons/medical_core/scripts/Game/ACE_Medical_Pain/Components/Damage/SCR_CharacterDamageManagerComponent.c
@@ -70,7 +70,7 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 	//! Add pain when armor blocks damage
 	//! Behavior:
 	//! - Small impacts below threshold are ignored
-	//! - First significant impact sets character to moderate pain state
+	//! - First significant impact sets character to moderate pain state + any additional pain from impact
 	//! - Subsequent hits when already beyond moderate don't add more pain
 	override void ArmorHitEventDamage(EDamageType type, float damage, IEntity instigator)
 	{
@@ -82,18 +82,17 @@ modded class SCR_CharacterDamageManagerComponent : SCR_DamageManagerComponent
 		if (damage < m_fACE_Medical_ArmorPainThreshold)
 			return;
 
-		// If already in pain (beyond moderate), don't add more
 		if (ACE_Medical_IsInPain())
 			return;
 
-		// Not in pain yet - apply pain to reach moderate threshold
-		float painDamage = damage * m_fACE_Medical_ArmorPainMultiplier;
-
 		float moderateThreshold = m_ACE_Medical_PainHitZone.GetDamageStateThreshold(ECharacterHealthState.MODERATE);
 		float currentHealth = m_ACE_Medical_PainHitZone.GetHealthScaled();
-		float minDamageForPain = (currentHealth - moderateThreshold) * m_ACE_Medical_PainHitZone.GetMaxHealth();
+		float damageToReachModerate = (currentHealth - moderateThreshold) * m_ACE_Medical_PainHitZone.GetMaxHealth();
 
-		painDamage = Math.Max(painDamage, minDamageForPain);
-		m_ACE_Medical_PainHitZone.HandleDamage(painDamage, EDamageType.TRUE, instigator);
+		float additionalPainDamage = damage * m_fACE_Medical_ArmorPainMultiplier;
+
+		float totalPainDamage = damageToReachModerate + additionalPainDamage;
+
+		m_ACE_Medical_PainHitZone.HandleDamage(totalPainDamage, EDamageType.TRUE, instigator);
 	}
 }


### PR DESCRIPTION
**When merged this pull request will:**
- This a near duplicate of #266 due to merge conflicts
- Adds pain effects when armor stops incoming kinetic/melee damage
  - First significant armor hit (above threshold) sets pain to MODERATE + additional damage based on multiplier
  - Subsequent hits while already in pain (at/beyond MODERATE) add no additional pain
  - Per maintainer's feedback: prevents armor spam from continuously increasing pain
- Adds configurable thresholds and modifiers for damage to pain hitzone from ArmorHitEvent()

Question... should first hit be capped at exactly MODERATE, or allowed to exceed based on impact severity (current implementation)?

Note: the configuration is at the prefab level.