### PR TITLE
Finger - Drop usage of world controller

### DIFF
--- a/addons/finger/Prefabs/Helpers/ACE_Finger_MapPointer.et
+++ b/addons/finger/Prefabs/Helpers/ACE_Finger_MapPointer.et
@@ -1,0 +1,9 @@
+ACE_Finger_MapPointer {
+ ID "65F71835764A9CD4"
+ components {
+  RplComponent "{65F7183541786025}" {
+   Streamable Disabled
+  }
+ }
+ coords 1.873 3.704 3.07
+}

--- a/addons/finger/Prefabs/Helpers/ACE_Finger_MapPointer.et.meta
+++ b/addons/finger/Prefabs/Helpers/ACE_Finger_MapPointer.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{177172E4559E8F95}Prefabs/Helpers/ACE_Finger_MapPointer.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/finger/scripts/Game/ACE_Finger/GameMode/SCR_BaseGameMode.c
+++ b/addons/finger/scripts/Game/ACE_Finger/GameMode/SCR_BaseGameMode.c
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------------------------
+modded class SCR_BaseGameMode : BaseGameMode
+{
+	protected ref map<int, ACE_Finger_MapPointer> m_aACE_Finger_Pointers = new map<int, ACE_Finger_MapPointer>();
+	
+	//------------------------------------------------------------------------------------------------
+	//! Create map pointer for the player
+	override void OnPlayerConnected(int playerId)
+	{
+		super.OnPlayerConnected(playerId);
+		
+		SCR_PlayerController playerController = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
+		if (!playerController)
+			return;
+		
+		Resource res = Resource.Load("{177172E4559E8F95}Prefabs/Helpers/ACE_Finger_MapPointer.et");
+		if (!res.IsValid())
+			return;
+		
+		ACE_Finger_MapPointer ptr = ACE_Finger_MapPointer.Cast(GetGame().SpawnEntityPrefab(res));
+		if (!ptr)
+			return;
+		
+		ptr.InitServer(playerId);
+		m_aACE_Finger_Pointers[playerId] = ptr;
+		
+		RplComponent ptrRpl = RplComponent.Cast(ptr.FindComponent(RplComponent));
+		if (!ptrRpl)
+			return;
+		
+		ptrRpl.Give(playerController.GetRplIdentity());
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	//! Delete map pointer of the player
+	override protected void OnPlayerDisconnected(int playerId, KickCauseCode cause, int timeout)
+	{
+		super.OnPlayerDisconnected(playerId, cause, timeout);
+		
+		ACE_Finger_MapPointer ptr;
+		if (m_aACE_Finger_Pointers.Take(playerId, ptr))
+			SCR_EntityHelper.DeleteEntityAndChildren(ptr);
+	}
+}

--- a/addons/finger/scripts/Game/ACE_Finger/GameMode/SCR_BaseGameMode.c
+++ b/addons/finger/scripts/Game/ACE_Finger/GameMode/SCR_BaseGameMode.c
@@ -5,9 +5,9 @@ modded class SCR_BaseGameMode : BaseGameMode
 	
 	//------------------------------------------------------------------------------------------------
 	//! Create map pointer for the player
-	override void OnPlayerConnected(int playerId)
+	override void OnPlayerRegistered(int playerId)
 	{
-		super.OnPlayerConnected(playerId);
+		super.OnPlayerRegistered(playerId);
 		
 		SCR_PlayerController playerController = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
 		if (!playerController)

--- a/addons/finger/scripts/Game/ACE_Finger/Map/ComponentsUI/ACE_Finger_MapUIPointerContainer.c
+++ b/addons/finger/scripts/Game/ACE_Finger/Map/ComponentsUI/ACE_Finger_MapUIPointerContainer.c
@@ -8,7 +8,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	[Attribute("{DD15734EB89D74E2}UI/layouts/Map/MapMarkerBase.layout", params: "layout")]
 	protected ResourceName m_sPointerElementName;
 	
-	protected ref array<ACE_Finger_MapPointerController> m_aPointers = {};
+	protected ref array<ACE_Finger_MapPointer> m_aPointers = {};
 	protected ref array<Widget> m_aWidgets = {};
 	
 	[Attribute(defvalue: "0.1", desc: "Pointer update timer [s]")]
@@ -39,7 +39,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	{
 		super.Update(timeSlice);
 		
-		ACE_Finger_MapPointerController ptr = ACE_Finger_MapPointerController.GetLocalInstance();
+		ACE_Finger_MapPointer ptr = ACE_Finger_MapPointer.GetLocalInstance();
 		if (ptr && ptr.IsToggleOn())
 		{
 			m_fPointerUpdateTimer += timeSlice;
@@ -55,14 +55,14 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 			}
 		}
 		
-		foreach (int i, ACE_Finger_MapPointerController otherPtr: m_aPointers)
+		foreach (int i, ACE_Finger_MapPointer otherPtr: m_aPointers)
 		{
 			UpdatePointerMarker(m_aWidgets[i], otherPtr);
 		}
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	protected void UpdatePointerMarker(Widget ptrWidget, ACE_Finger_MapPointerController ptr)
+	protected void UpdatePointerMarker(Widget ptrWidget, ACE_Finger_MapPointer ptr)
 	{
 		bool visible = ShouldPointerBeVisible(ptr);
 		ptrWidget.SetVisible(visible);
@@ -77,12 +77,12 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	
 	//------------------------------------------------------------------------------------------------
 	//! Should only be visible if the player that points is nearby
-	protected bool ShouldPointerBeVisible(ACE_Finger_MapPointerController ptr)
+	protected bool ShouldPointerBeVisible(ACE_Finger_MapPointer ptr)
 	{
 		if (!m_pLocalPlayerChar)
 			return false;
 		
-		IEntity ptrPlayer = GetGame().GetPlayerManager().GetPlayerControlledEntity(ptr.ACE_GetOwnerPlayerId());
+		IEntity ptrPlayer = GetGame().GetPlayerManager().GetPlayerControlledEntity(ptr.GetOwnerPlayerID());
 		if (!ptrPlayer)
 			return false;
 		
@@ -106,7 +106,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	//------------------------------------------------------------------------------------------------
 	protected void PointerOnAction(float value, EActionTrigger reason)
 	{
-		ACE_Finger_MapPointerController ptr = ACE_Finger_MapPointerController.GetLocalInstance();
+		ACE_Finger_MapPointer ptr = ACE_Finger_MapPointer.GetLocalInstance();
 		if (!ptr)
 			return;
 		
@@ -125,7 +125,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	//------------------------------------------------------------------------------------------------
 	protected void PointerOffAction(float value, EActionTrigger reason)
 	{
-		ACE_Finger_MapPointerController ptr = ACE_Finger_MapPointerController.GetLocalInstance();
+		ACE_Finger_MapPointer ptr = ACE_Finger_MapPointer.GetLocalInstance();
 		if (!ptr)
 			return;
 		
@@ -137,9 +137,9 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	void AddPointer(ACE_Finger_MapPointerController ptr)
+	void AddPointer(ACE_Finger_MapPointer ptr)
 	{
-		if (ptr == ACE_Finger_MapPointerController.GetLocalInstance())
+		if (ptr == ACE_Finger_MapPointer.GetLocalInstance())
 			return;
 		
 		WorkspaceWidget workspace = GetGame().GetWorkspace();
@@ -157,7 +157,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 		handler.SetImage("{4020BDDA0BA7D5CF}UI/Textures/Icons/icons_gamepad/icons_gamepad.imageset", "stick_hold");
 		handler.ACE_ResizeImage(0.6, 0.6);
 		handler.SetColor(Color.Orange);
-		handler.SetAuthor(GetGame().GetPlayerManager().GetPlayerName(ptr.ACE_GetOwnerPlayerId()));
+		handler.SetAuthor(GetGame().GetPlayerManager().GetPlayerName(ptr.GetOwnerPlayerID()));
 		handler.SetAuthorVisible(true);
 		
 		m_aPointers.Insert(ptr);
@@ -165,9 +165,9 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	void RemovePointer(ACE_Finger_MapPointerController ptr)
+	void RemovePointer(ACE_Finger_MapPointer ptr)
 	{
-		if (ptr == ACE_Finger_MapPointerController.GetLocalInstance())
+		if (ptr == ACE_Finger_MapPointer.GetLocalInstance())
 			return;
 		
 		int i = m_aPointers.Find(ptr);
@@ -186,7 +186,7 @@ class ACE_Finger_MapUIPointerContainer : SCR_MapUIBaseComponent
 	//------------------------------------------------------------------------------------------------
 	void ClearPointers()
 	{
-		foreach (ACE_Finger_MapPointerController ptr : m_aPointers)
+		foreach (ACE_Finger_MapPointer ptr : m_aPointers)
 		{
 			RemovePointer(ptr);
 		}

--- a/addons/finger/scripts/Game/ACE_Finger/Systems/ACE_Finger_MapPointingSystem.c
+++ b/addons/finger/scripts/Game/ACE_Finger/Systems/ACE_Finger_MapPointingSystem.c
@@ -3,7 +3,7 @@
 class ACE_Finger_MapPointingSystem : GameSystem
 {
 	protected ACE_Finger_MapUIPointerContainer m_pContainer;
-	protected ref array<ACE_Finger_MapPointerController> m_aActivePointers = {};
+	protected ref array<ACE_Finger_MapPointer> m_aActivePointers = {};
 	
 	//------------------------------------------------------------------------------------------------
 	static ACE_Finger_MapPointingSystem GetInstance()
@@ -19,12 +19,11 @@ class ACE_Finger_MapPointingSystem : GameSystem
 		outInfo.SetAbstract(false)
 			.SetUnique(true)
 			.SetLocation(WorldSystemLocation.Client)
-			.AddPoint(WorldSystemPoint.RuntimeStarted)
-			.AddController(ACE_Finger_MapPointerController);
+			.AddPoint(WorldSystemPoint.BeforeEntitiesCreated);
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	void RegisterActivePointer(ACE_Finger_MapPointerController ptr)
+	void RegisterActivePointer(ACE_Finger_MapPointer ptr)
 	{
 		if (m_pContainer)
 			m_pContainer.AddPointer(ptr);
@@ -33,7 +32,7 @@ class ACE_Finger_MapPointingSystem : GameSystem
 	}
 		
 	//------------------------------------------------------------------------------------------------
-	void UnregisterActivePointer(ACE_Finger_MapPointerController ptr)
+	void UnregisterActivePointer(ACE_Finger_MapPointer ptr)
 	{
 		if (m_pContainer)
 			m_pContainer.RemovePointer(ptr);
@@ -46,7 +45,7 @@ class ACE_Finger_MapPointingSystem : GameSystem
 	{
 		m_pContainer = container;
 		
-		foreach (ACE_Finger_MapPointerController ptr : m_aActivePointers)
+		foreach (ACE_Finger_MapPointer ptr : m_aActivePointers)
 		{
 			m_pContainer.AddPointer(ptr);
 		}


### PR DESCRIPTION
**When merged this pull request will:**
- Reverts #322 
- Use `OnPlayerRegistered` instead of `OnPlayerConnected` for spawning helper.

**Background:**
- World controllers seem to be still WIP and can currently break dedicated servers.
