### PR TITLE
Medical Core - Show fracture info when inspecting casualty

### DIFF
--- a/addons/medical_core/scripts/Game/@ACE_Medical_Core/UI/Inventory/SCR_InventoryDamageInfoUI.c
+++ b/addons/medical_core/scripts/Game/@ACE_Medical_Core/UI/Inventory/SCR_InventoryDamageInfoUI.c
@@ -1,0 +1,32 @@
+//------------------------------------------------------------------------------------------------
+[EntityEditorProps(category: "GameScripted/UI/Inventory", description: "Inventory Item Info UI class")]
+modded class SCR_InventoryDamageInfoUI : ScriptedWidgetComponent
+{
+	//------------------------------------------------------------------------------------------------
+	//! Fix broken vanilla implementation for inspect casualty widget
+	//! i.e. handle case where m_wFractureIcon2Widget does not exist
+	override void SetFractureStateVisible(bool armFractured, bool legFractured)
+	{
+		super.SetFractureStateVisible(armFractured, legFractured);
+		
+		// if m_wFractureIcon2Widget exists, it's already properly handled by vanilla
+		if (m_wFractureIcon2Widget || !m_wFractureIconWidget || !m_wFractureTextWidget)
+			return;
+		
+		m_wFractureIconWidget.LoadImageFromSet(0, m_sMedicalIconsImageSet, m_sFractureIcon);
+		m_wFractureIconWidget.SetVisible(armFractured || legFractured);
+		
+		string text;
+		if (armFractured)
+			text += m_sArmFractureText;
+		
+		if (armFractured && legFractured)
+			text += "\n";
+		
+		if (legFractured)
+			text += m_sLegFractureText;
+
+		m_wFractureTextWidget.SetText(text);
+		m_wFractureTextWidget.SetVisible(armFractured || legFractured);
+	}
+}

--- a/addons/medical_core/scripts/Game/@ACE_Medical_Core/UI/ScreenEffects/SCR_InspectCasualtyWidget.c
+++ b/addons/medical_core/scripts/Game/@ACE_Medical_Core/UI/ScreenEffects/SCR_InspectCasualtyWidget.c
@@ -1,6 +1,28 @@
 //------------------------------------------------------------------------------------------------
 modded class SCR_InspectCasualtyWidget : SCR_InfoDisplayExtended
 {
+	//------------------------------------------------------------------------------------------------
+	//! Add fracture data
+	override void UpdateWidgetData()
+	{
+		super.UpdateWidgetData();
+		
+		if (!m_Target || !m_wCasualtyInspectWidget)
+			return;
+		
+		SCR_InventoryDamageInfoUI damageInfoUI = SCR_InventoryDamageInfoUI.Cast(m_wCasualtyInspectWidget.FindHandler(SCR_InventoryDamageInfoUI));
+		if (!damageInfoUI)
+			return;
+		
+		SCR_CharacterDamageManagerComponent damageManager = SCR_CharacterDamageManagerComponent.Cast(m_Target.FindComponent(SCR_CharacterDamageManagerComponent));
+		if (!damageManager)
+			return;
+		
+		damageInfoUI.SetFractureStateVisible(damageManager.GetAimingDamage() > 0, damageManager.GetMovementDamage() > 0);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	//! Get global health from ACE getter
 	override protected void GetDamageInfo(SCR_InventoryHitZonePointUI hitZonePointUI, IEntity targetEntity, inout float bleedingRate, inout array<bool> hZGroupsBleeding, inout int damageIntensity, inout bool regenerating, inout bool isTourniquetted, inout bool isSalineBagged, inout bool isMorphined)
 	{
 		super.GetDamageInfo(hitZonePointUI, targetEntity, bleedingRate, hZGroupsBleeding, damageIntensity, regenerating, isTourniquetted, isSalineBagged, isMorphined);


### PR DESCRIPTION
**When merged this pull request will:**
- See title

**Background:**
- Fracture info is already shown in inventory, but not in casualty inspection.
- Casualty inspection layout has `m_wFractureIconWidget`, but not `m_wFractureIcon2Widget`, unlike inventory
