### PR TITLE
Overheating - Add missing hierarchy component

### DIFF
--- a/addons/overheating/Prefabs/Weapons/Attachments/Muzzle/ACE_Overheating_HelperAttachment.et
+++ b/addons/overheating/Prefabs/Weapons/Attachments/Muzzle/ACE_Overheating_HelperAttachment.et
@@ -1,3 +1,7 @@
 GenericEntity {
  ID "663201D392ACB012"
+ components {
+  Hierarchy "{68D8F8184715C9E3}" {
+  }
+ }
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Hierarchy` component to `ACE_Overheating_HelperAttachment.et`
