### PR TITLE
Medical Core - Make Tourniquets stronger

### DIFF
--- a/addons/medical_core/Prefabs/Characters/Core/DamageManager_Character_Base.ct
+++ b/addons/medical_core/Prefabs/Characters/Core/DamageManager_Character_Base.ct
@@ -30,4 +30,5 @@ SCR_CharacterDamageManagerComponent {
    MaxHealth 100
   }
  }
+ m_fTourniquetStrengthMultiplier 0.001
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Increase reduction of bleeding rate from 95% to 99.9% for tourniquets.

**Background:**
- In contrast to Reforger, ACE3's Tourniquets  completely stop bleedings.
- 100% is currently not possible in Reforger, as it will break bandages and tourniquets.
