### PR TITLE
Medical Core - Fix damage type was not properly set for blood loss effect

### DIFF
--- a/addons/medical_core/scripts/Game/ACE_Medical_Bleeding/Damage/DamageEffects/CharacterDamageEffects/SCR_BleedingDamageEffect.c
+++ b/addons/medical_core/scripts/Game/ACE_Medical_Bleeding/Damage/DamageEffects/CharacterDamageEffects/SCR_BleedingDamageEffect.c
@@ -18,6 +18,7 @@ modded class SCR_BleedingDamageEffect : SCR_DotDamageEffect
 		
 		ACE_Medical_BloodLossDamageEffect bloodLossDamageEffect = new ACE_Medical_BloodLossDamageEffect();
 		bloodLossDamageEffect.SetMaxDuration(0);
+		bloodLossDamageEffect.SetDamageType(EDamageType.BLEEDING);
 		bloodLossDamageEffect.SetInstigator(GetInstigator());
 		dmgManager.AddDamageEffect(bloodLossDamageEffect);
 	}


### PR DESCRIPTION
**When merged this pull request will:**
- Explicitly set damage type on effect

**Background:**
- Not setting the damage type will lead to a crash in `1.7.x.x`
- Overriding `GetDefaultDamageType` is not enough for properly setting the damage type