### PR TITLE
Unit Markers - Add GM unit marker overlay on map

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__enfusion-mcp__api_search"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "mcp__enfusion-mcp__api_search"
+      "mcp__enfusion-mcp__api_search",
+      "mcp__enfusion-mcp__game_read",
+      "mcp__enfusion-mcp__game_browse"
     ]
   }
 }

--- a/addons/unit_markers/Configs/Map/MapFullscreen.conf
+++ b/addons/unit_markers/Configs/Map/MapFullscreen.conf
@@ -1,6 +1,2 @@
 SCR_MapConfig {
- m_aUIComponents {
-  ACE_UnitMarkers_MapModule "{7F3B1C09E54A2D88}" {
-  }
- }
 }

--- a/addons/unit_markers/Configs/Map/MapFullscreen.conf
+++ b/addons/unit_markers/Configs/Map/MapFullscreen.conf
@@ -1,0 +1,6 @@
+SCR_MapConfig {
+ m_aUIComponents {
+  ACE_UnitMarkers_MapModule "{7F3B1C09E54A2D88}" {
+  }
+ }
+}

--- a/addons/unit_markers/Configs/Map/MapFullscreen.conf.meta
+++ b/addons/unit_markers/Configs/Map/MapFullscreen.conf.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{4A8F21C3DB992701}Configs/Map/MapFullscreen.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/unit_markers/Missions/markertest.conf
+++ b/addons/unit_markers/Missions/markertest.conf
@@ -1,0 +1,8 @@
+SCR_MissionHeader {
+ World "{45EBE7AE233357CD}test/worlds/markertest.ent"
+ m_sName "<Insert world name>"
+ m_sAuthor "<Insert your name>"
+ m_sDescription "<Insert world description>"
+ m_sGameMode "#AR-Scenario_GameMode_GameMaster"
+ m_iPlayerCount 64
+}

--- a/addons/unit_markers/Missions/markertest.conf.meta
+++ b/addons/unit_markers/Missions/markertest.conf.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{F258874696D6CF9D}Missions/markertest.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/unit_markers/addon.gproj
+++ b/addons/unit_markers/addon.gproj
@@ -1,0 +1,8 @@
+GameProject {
+ ID "ACE_UnitMarkers"
+ GUID "63A9FD22C7B548A1"
+ TITLE "ACE Unit Markers"
+ Dependencies {
+  "58D0FB3206B6F859" "60C4CE4888FF4621"
+ }
+}

--- a/addons/unit_markers/license.txt
+++ b/addons/unit_markers/license.txt
@@ -1,0 +1,18 @@
+ACE Anvil - An experimental realism mod for Arma Reforger
+Copyright (C) 2024  acemod
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+When publishing a derivative of this product you may not use a name that
+might create the impression that your version is an official release.
+
+A full copy of this license can be found at the following address:
+https://github.com/acemod/ACE-Anvil/blob/master/LICENSE.

--- a/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapInjectorComponent.c
+++ b/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapInjectorComponent.c
@@ -1,0 +1,34 @@
+[ComponentEditorProps(category: "ACE/UnitMarkers", description: "Injects ACE_UnitMarkers_MapModule into editor (GM) map configs at runtime.")]
+class ACE_UnitMarkers_MapInjectorComponentClass : SCR_BaseGameModeComponentClass {}
+
+class ACE_UnitMarkers_MapInjectorComponent : SCR_BaseGameModeComponent
+{
+	//------------------------------------------------------------------------------------------------
+	override protected void OnPostInit(IEntity owner)
+	{
+		super.OnPostInit(owner);
+
+		if (SCR_Global.IsEditMode())
+			return;
+
+		SCR_MapEntity.GetOnMapInit().Insert(OnMapInit);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void OnMapInit(MapConfiguration config)
+	{
+		// Only inject into editor/GM maps, not gadget or respawn maps
+		if (config.MapEntityMode != EMapEntityMode.EDITOR)
+			return;
+
+		// Check if our component is already present (e.g. added via map config file)
+		foreach (SCR_MapUIBaseComponent comp : config.Components)
+		{
+			if (comp.IsInherited(ACE_UnitMarkers_MapModule))
+				return;
+		}
+
+		config.Components.Insert(new ACE_UnitMarkers_MapModule());
+		Print("[ACE_UnitMarkers] Injected ACE_UnitMarkers_MapModule into editor map config", LogLevel.NORMAL);
+	}
+}

--- a/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
+++ b/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
@@ -102,13 +102,27 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	//! Iterates all world entities and collects those that should have a GM marker.
 	protected void CollectTrackedEntities(out array<IEntity> entities)
 	{
-		IEntity ent = GetGame().GetWorld().GetFirstEntity();
-		while (ent)
-		{
-			if (ShouldTrack(ent))
-				entities.Insert(ent);
-			ent = GetGame().GetWorld().GetNextEntity(ent);
-		}
+		GetGame().GetWorld().QueryEntitiesByAABB(
+			Vector(-1000000, 0, -1000000),
+			Vector(1000000, 10000, 1000000),
+			QueryEntitiesCallback_ShouldTrack,
+			null,
+			EQueryEntitiesFlags.ALL
+		);
+
+		// QueryEntitiesByAABB callbacks can't write to a local out array directly,
+		// so we use a temporary member and swap after the call.
+		entities = m_aQueryResults;
+		m_aQueryResults = new array<IEntity>();
+	}
+
+	protected ref array<IEntity> m_aQueryResults = new array<IEntity>();
+
+	protected bool QueryEntitiesCallback_ShouldTrack(IEntity ent)
+	{
+		if (ShouldTrack(ent))
+			m_aQueryResults.Insert(ent);
+		return true;
 	}
 
 	//------------------------------------------------------------------------------------------------
@@ -253,7 +267,7 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 		Vehicle vehicle = Vehicle.Cast(ent);
 		if (vehicle)
 		{
-			if (Helicopter.Cast(vehicle))
+			if (vehicle.FindComponent(HelicopterControllerComponent))
 			{
 				icon = EMilitarySymbolIcon.ROTARY_WING;
 				dimension = EMilitarySymbolDimension.AIR;
@@ -262,7 +276,7 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 
 			// Armed ground vehicles (tanks, IFVs, armed APCs) get the ARMOR symbol;
 			// unarmed transports (trucks, jeeps) get the MOTORIZED symbol.
-			if (vehicle.FindComponent(WeaponManagerComponent))
+			if (vehicle.FindComponent(TurretControllerComponent))
 				icon = EMilitarySymbolIcon.ARMOR;
 			else
 				icon = EMilitarySymbolIcon.MOTORIZED;

--- a/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
+++ b/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
@@ -1,0 +1,362 @@
+//------------------------------------------------------------------------------------------------
+//! Map UI component that shows unit markers to gamemasters when the map is open.
+//! Infantry: NATO infantry symbol with cardinal direction label.
+//! Helicopters: NATO rotary-wing symbol (circle frame).
+//! Armed ground vehicles: NATO armor symbol.
+//! Unarmed ground vehicles: NATO motorized symbol.
+//! All markers are colored by faction (BLUFOR=blue, OPFOR=red, INDFOR=green).
+//! Markers are local-only and not networked.
+class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
+{
+	protected static const float UPDATE_INTERVAL_S = 1.5;
+
+	protected float m_fUpdateTimer = 0;
+	protected bool m_bActive = false;
+
+	// Parallel arrays - entity reference and its corresponding map marker
+	protected ref array<IEntity> m_aTrackedEntities = {};
+	protected ref array<SCR_MapMarkerBase> m_aMarkers = {};
+
+	//------------------------------------------------------------------------------------------------
+	override protected void OnMapOpen(MapConfiguration config)
+	{
+		super.OnMapOpen(config);
+
+		if (!IsLocalPlayerGameMaster())
+			return;
+
+		m_bActive = true;
+		m_fUpdateTimer = UPDATE_INTERVAL_S; // trigger an update on the first Update() call
+	}
+
+	//------------------------------------------------------------------------------------------------
+	override protected void OnMapClose(MapConfiguration config)
+	{
+		super.OnMapClose(config);
+		m_bActive = false;
+		ClearAllMarkers();
+	}
+
+	//------------------------------------------------------------------------------------------------
+	override void Update(float timeSlice)
+	{
+		super.Update(timeSlice);
+
+		if (!m_bActive)
+			return;
+
+		m_fUpdateTimer += timeSlice;
+		if (m_fUpdateTimer < UPDATE_INTERVAL_S)
+			return;
+
+		m_fUpdateTimer = 0;
+		UpdateMarkers();
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Returns true when the local player has a non-limited editor (GM) instance.
+	protected bool IsLocalPlayerGameMaster()
+	{
+		SCR_EditorManagerEntity editorManager = SCR_EditorManagerEntity.GetInstance();
+		return editorManager != null && !editorManager.IsLimited();
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void UpdateMarkers()
+	{
+		SCR_MapMarkerManagerComponent markerManager = GetMarkerManager();
+		if (!markerManager)
+			return;
+
+		array<IEntity> currentEntities = {};
+		CollectTrackedEntities(currentEntities);
+
+		// Remove markers for entities that are no longer tracked
+		for (int i = m_aTrackedEntities.Count() - 1; i >= 0; i--)
+		{
+			if (!currentEntities.Contains(m_aTrackedEntities[i]))
+				RemoveMarkerAt(markerManager, i);
+		}
+
+		// Create new markers or refresh positions of existing ones
+		foreach (IEntity ent : currentEntities)
+		{
+			int idx = m_aTrackedEntities.Find(ent);
+			if (idx < 0)
+			{
+				SCR_MapMarkerBase marker = CreateMarker(markerManager, ent);
+				if (marker)
+				{
+					m_aTrackedEntities.Insert(ent);
+					m_aMarkers.Insert(marker);
+				}
+			}
+			else
+			{
+				RefreshMarker(m_aMarkers[idx], ent);
+			}
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Iterates all world entities and collects those that should have a GM marker.
+	protected void CollectTrackedEntities(out array<IEntity> entities)
+	{
+		IEntity ent = GetGame().GetWorld().GetFirstEntity();
+		while (ent)
+		{
+			if (ShouldTrack(ent))
+				entities.Insert(ent);
+			ent = GetGame().GetWorld().GetNextEntity(ent);
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Returns true for living infantry not in a vehicle, and for vehicles that have occupants.
+	protected bool ShouldTrack(IEntity ent)
+	{
+		ChimeraCharacter character = ChimeraCharacter.Cast(ent);
+		if (character)
+		{
+			SCR_CharacterControllerComponent ctrl = SCR_CharacterControllerComponent.Cast(
+				character.FindComponent(SCR_CharacterControllerComponent)
+			);
+			if (ctrl && ctrl.IsDead())
+				return false;
+
+			// Vehicle marker covers occupants - skip characters sitting inside a vehicle
+			if (IsInVehicle(character))
+				return false;
+
+			return true;
+		}
+
+		Vehicle vehicle = Vehicle.Cast(ent);
+		if (vehicle)
+			return VehicleHasOccupants(vehicle);
+
+		return false;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Walks the entity parent chain to determine whether the character is inside a vehicle.
+	protected bool IsInVehicle(ChimeraCharacter character)
+	{
+		IEntity parent = character.GetParent();
+		while (parent)
+		{
+			if (Vehicle.Cast(parent))
+				return true;
+			parent = parent.GetParent();
+		}
+		return false;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Checks child entities for at least one ChimeraCharacter occupant.
+	protected bool VehicleHasOccupants(Vehicle vehicle)
+	{
+		IEntity child = vehicle.GetChildren();
+		while (child)
+		{
+			if (ChimeraCharacter.Cast(child))
+				return true;
+			child = child.GetSibling();
+		}
+		return false;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected SCR_MapMarkerBase CreateMarker(SCR_MapMarkerManagerComponent markerManager, IEntity ent)
+	{
+		EMilitarySymbolIdentity identity = GetEntityIdentity(ent);
+		EMilitarySymbolIcon icon;
+		EMilitarySymbolDimension dimension;
+		GetEntitySymbol(ent, icon, dimension);
+
+		SCR_MapMarkerBase marker = markerManager.PrepareMilitaryMarker(identity, dimension, icon);
+
+		// Faction identity may not be configured in the scenario - fall back to UNKNOWN
+		if (!marker && identity != EMilitarySymbolIdentity.UNKNOWN)
+			marker = markerManager.PrepareMilitaryMarker(EMilitarySymbolIdentity.UNKNOWN, dimension, icon);
+
+		if (!marker)
+			return null;
+
+		vector pos = ent.GetOrigin();
+		marker.SetWorldPos((int)pos[0], (int)pos[2]);
+		marker.SetCustomText(BuildMarkerLabel(ent));
+
+		// true = local-only, not broadcast over network
+		markerManager.InsertStaticMarker(marker, true);
+		return marker;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void RefreshMarker(SCR_MapMarkerBase marker, IEntity ent)
+	{
+		if (!marker || !ent)
+			return;
+
+		vector pos = ent.GetOrigin();
+		marker.SetWorldPos((int)pos[0], (int)pos[2]);
+		marker.SetCustomText(BuildMarkerLabel(ent));
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected EMilitarySymbolIdentity GetEntityIdentity(IEntity ent)
+	{
+		FactionAffiliationComponent factionComp = FactionAffiliationComponent.Cast(
+			ent.FindComponent(FactionAffiliationComponent)
+		);
+		if (!factionComp)
+			return EMilitarySymbolIdentity.UNKNOWN;
+
+		Faction faction = factionComp.GetAffiliatedFaction();
+		if (!faction)
+			return EMilitarySymbolIdentity.UNKNOWN;
+
+		return ResolveIdentityForFaction(faction.GetFactionKey());
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Maps vanilla Reforger faction keys to NATO military symbol identities.
+	//! Extend this list to support custom faction keys from other mods or missions.
+	protected EMilitarySymbolIdentity ResolveIdentityForFaction(string factionKey)
+	{
+		if (factionKey == "US" || factionKey == "US_Army" || factionKey == "NATO" || factionKey == "BLUFOR")
+			return EMilitarySymbolIdentity.BLUFOR;
+
+		if (factionKey == "USSR" || factionKey == "Soviet" || factionKey == "OPFOR" || factionKey == "RU")
+			return EMilitarySymbolIdentity.OPFOR;
+
+		if (factionKey == "FIA" || factionKey == "INDFOR" || factionKey == "Guerrilla" || factionKey == "Resistance")
+			return EMilitarySymbolIdentity.INDFOR;
+
+		return EMilitarySymbolIdentity.UNKNOWN;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Assigns the NATO military symbol icon and operational dimension for an entity.
+	//! Helicopters use the AIR dimension (circle frame).
+	//! Armed ground vehicles receive the ARMOR icon; unarmed ones receive MOTORIZED.
+	//! Infantry always receive the INFANTRY icon on the LAND dimension.
+	protected void GetEntitySymbol(IEntity ent, out EMilitarySymbolIcon icon, out EMilitarySymbolDimension dimension)
+	{
+		if (ChimeraCharacter.Cast(ent))
+		{
+			icon = EMilitarySymbolIcon.INFANTRY;
+			dimension = EMilitarySymbolDimension.LAND;
+			return;
+		}
+
+		Vehicle vehicle = Vehicle.Cast(ent);
+		if (vehicle)
+		{
+			if (Helicopter.Cast(vehicle))
+			{
+				icon = EMilitarySymbolIcon.ROTARY_WING;
+				dimension = EMilitarySymbolDimension.AIR;
+				return;
+			}
+
+			// Armed ground vehicles (tanks, IFVs, armed APCs) get the ARMOR symbol;
+			// unarmed transports (trucks, jeeps) get the MOTORIZED symbol.
+			if (vehicle.FindComponent(WeaponManagerComponent))
+				icon = EMilitarySymbolIcon.ARMOR;
+			else
+				icon = EMilitarySymbolIcon.MOTORIZED;
+
+			dimension = EMilitarySymbolDimension.LAND;
+			return;
+		}
+
+		icon = EMilitarySymbolIcon.INFANTRY;
+		dimension = EMilitarySymbolDimension.LAND;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Builds the text label shown beneath the marker.
+	//! Infantry: player name (if applicable) + cardinal direction in brackets, e.g. "Smith [NE]".
+	//! Vehicles: player name of the driver if player-controlled, otherwise empty.
+	protected string BuildMarkerLabel(IEntity ent)
+	{
+		string playerName = string.Empty;
+		int playerID = GetGame().GetPlayerManager().GetPlayerIdFromControlledEntity(ent);
+		if (playerID > 0)
+			playerName = GetGame().GetPlayerManager().GetPlayerName(playerID);
+
+		if (ChimeraCharacter.Cast(ent))
+		{
+			string direction = GetCardinalDirection(ent);
+			if (playerName.IsEmpty())
+				return direction;
+			return playerName + " " + direction;
+		}
+
+		return playerName;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Returns a cardinal direction string for the entity's current facing, e.g. "[NE]".
+	//! Uses the forward vector from the entity's world transform matrix.
+	//! In Enfusion: X=east, Z=north; yaw 0=north, increasing clockwise.
+	protected string GetCardinalDirection(IEntity ent)
+	{
+		vector mat[4];
+		ent.GetWorldTransform(mat);
+
+		// mat[2] is the forward (look) direction in world space
+		float yaw = Math.Atan2(mat[2][0], mat[2][2]) * Math.RAD2DEG;
+		if (yaw < 0)
+			yaw += 360;
+
+		if (yaw < 22.5 || yaw >= 337.5) return "[N]";
+		if (yaw < 67.5)                 return "[NE]";
+		if (yaw < 112.5)                return "[E]";
+		if (yaw < 157.5)                return "[SE]";
+		if (yaw < 202.5)                return "[S]";
+		if (yaw < 247.5)                return "[SW]";
+		if (yaw < 292.5)                return "[W]";
+		return "[NW]";
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void RemoveMarkerAt(SCR_MapMarkerManagerComponent markerManager, int idx)
+	{
+		if (m_aMarkers[idx])
+			markerManager.RemoveStaticMarker(m_aMarkers[idx]);
+
+		m_aTrackedEntities.Remove(idx);
+		m_aMarkers.Remove(idx);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void ClearAllMarkers()
+	{
+		SCR_MapMarkerManagerComponent markerManager = GetMarkerManager();
+		if (markerManager)
+		{
+			foreach (SCR_MapMarkerBase marker : m_aMarkers)
+			{
+				if (marker)
+					markerManager.RemoveStaticMarker(marker);
+			}
+		}
+
+		m_aTrackedEntities.Clear();
+		m_aMarkers.Clear();
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected SCR_MapMarkerManagerComponent GetMarkerManager()
+	{
+		BaseGameMode gameMode = GetGame().GetGameMode();
+		if (!gameMode)
+			return null;
+
+		return SCR_MapMarkerManagerComponent.Cast(
+			gameMode.FindComponent(SCR_MapMarkerManagerComponent)
+		);
+	}
+}

--- a/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
+++ b/addons/unit_markers/scripts/Game/ACE_UnitMarkers/Map/ACE_UnitMarkers_MapModule.c
@@ -9,30 +9,36 @@
 class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 {
 	protected static const float UPDATE_INTERVAL_S = 1.5;
+	protected static const int MARKER_SIZE_PX = 16;
+	protected static const string MILITARY_IMAGESET = "{3A89628ECBF03E7C}UI/Textures/Map/icons_map_military/icons_map_military.imageset";
 
 	protected float m_fUpdateTimer = 0;
 	protected bool m_bActive = false;
 
-	// Parallel arrays - entity reference and its corresponding map marker
+	// Parallel arrays: world entity -> overlay widget root
 	protected ref array<IEntity> m_aTrackedEntities = {};
-	protected ref array<SCR_MapMarkerBase> m_aMarkers = {};
+	protected ref array<Widget> m_aWidgets = {};
 
 	//------------------------------------------------------------------------------------------------
 	override protected void OnMapOpen(MapConfiguration config)
 	{
 		super.OnMapOpen(config);
 
-		if (!IsLocalPlayerGameMaster())
+		bool isGM = IsLocalPlayerGameMaster();
+		Print(string.Format("[ACE_UnitMarkers] OnMapOpen - IsGM: %1", isGM), LogLevel.NORMAL);
+
+		if (!isGM)
 			return;
 
 		m_bActive = true;
-		m_fUpdateTimer = UPDATE_INTERVAL_S; // trigger an update on the first Update() call
+		m_fUpdateTimer = UPDATE_INTERVAL_S;
 	}
 
 	//------------------------------------------------------------------------------------------------
 	override protected void OnMapClose(MapConfiguration config)
 	{
 		super.OnMapClose(config);
+		Print("[ACE_UnitMarkers] OnMapClose", LogLevel.NORMAL);
 		m_bActive = false;
 		ClearAllMarkers();
 	}
@@ -54,7 +60,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Returns true when the local player has a non-limited editor (GM) instance.
 	protected bool IsLocalPlayerGameMaster()
 	{
 		SCR_EditorManagerEntity editorManager = SCR_EditorManagerEntity.GetInstance();
@@ -64,42 +69,49 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	//------------------------------------------------------------------------------------------------
 	protected void UpdateMarkers()
 	{
-		SCR_MapMarkerManagerComponent markerManager = GetMarkerManager();
-		if (!markerManager)
-			return;
-
 		array<IEntity> currentEntities = {};
 		CollectTrackedEntities(currentEntities);
 
-		// Remove markers for entities that are no longer tracked
+		Print(string.Format("[ACE_UnitMarkers] UpdateMarkers - found %1 trackable entities", currentEntities.Count()), LogLevel.NORMAL);
+
+		// Remove markers for entities no longer tracked
 		for (int i = m_aTrackedEntities.Count() - 1; i >= 0; i--)
 		{
 			if (!currentEntities.Contains(m_aTrackedEntities[i]))
-				RemoveMarkerAt(markerManager, i);
+				RemoveMarkerAt(i);
 		}
 
-		// Create new markers or refresh positions of existing ones
+		// Create or refresh
+		int created = 0;
+		int failed = 0;
 		foreach (IEntity ent : currentEntities)
 		{
 			int idx = m_aTrackedEntities.Find(ent);
 			if (idx < 0)
 			{
-				SCR_MapMarkerBase marker = CreateMarker(markerManager, ent);
-				if (marker)
+				Widget w = CreateMarkerWidget(ent);
+				if (w)
 				{
 					m_aTrackedEntities.Insert(ent);
-					m_aMarkers.Insert(marker);
+					m_aWidgets.Insert(w);
+					created++;
+				}
+				else
+				{
+					failed++;
 				}
 			}
 			else
 			{
-				RefreshMarker(m_aMarkers[idx], ent);
+				RefreshMarkerWidget(m_aWidgets[idx], ent);
 			}
 		}
+
+		if (created > 0 || failed > 0)
+			Print(string.Format("[ACE_UnitMarkers] UpdateMarkers - created: %1, failed: %2, total tracked: %3", created, failed, m_aTrackedEntities.Count()), LogLevel.NORMAL);
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Iterates all world entities and collects those that should have a GM marker.
 	protected void CollectTrackedEntities(out array<IEntity> entities)
 	{
 		GetGame().GetWorld().QueryEntitiesByAABB(
@@ -110,8 +122,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 			EQueryEntitiesFlags.ALL
 		);
 
-		// QueryEntitiesByAABB callbacks can't write to a local out array directly,
-		// so we use a temporary member and swap after the call.
 		entities = m_aQueryResults;
 		m_aQueryResults = new array<IEntity>();
 	}
@@ -126,7 +136,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Returns true for living infantry not in a vehicle, and for vehicles that have occupants.
 	protected bool ShouldTrack(IEntity ent)
 	{
 		ChimeraCharacter character = ChimeraCharacter.Cast(ent);
@@ -138,7 +147,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 			if (ctrl && ctrl.IsDead())
 				return false;
 
-			// Vehicle marker covers occupants - skip characters sitting inside a vehicle
 			if (IsInVehicle(character))
 				return false;
 
@@ -153,7 +161,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Walks the entity parent chain to determine whether the character is inside a vehicle.
 	protected bool IsInVehicle(ChimeraCharacter character)
 	{
 		IEntity parent = character.GetParent();
@@ -167,7 +174,6 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Checks child entities for at least one ChimeraCharacter occupant.
 	protected bool VehicleHasOccupants(Vehicle vehicle)
 	{
 		IEntity child = vehicle.GetChildren();
@@ -181,118 +187,122 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	protected SCR_MapMarkerBase CreateMarker(SCR_MapMarkerManagerComponent markerManager, IEntity ent)
+	//! Creates an overlay widget parented to the map canvas for this entity.
+	protected Widget CreateMarkerWidget(IEntity ent)
 	{
-		EMilitarySymbolIdentity identity = GetEntityIdentity(ent);
-		EMilitarySymbolIcon icon;
-		EMilitarySymbolDimension dimension;
-		GetEntitySymbol(ent, icon, dimension);
-
-		SCR_MapMarkerBase marker = markerManager.PrepareMilitaryMarker(identity, dimension, icon);
-
-		// Faction identity may not be configured in the scenario - fall back to UNKNOWN
-		if (!marker && identity != EMilitarySymbolIdentity.UNKNOWN)
-			marker = markerManager.PrepareMilitaryMarker(EMilitarySymbolIdentity.UNKNOWN, dimension, icon);
-
-		if (!marker)
+		CanvasWidget canvas = m_MapEntity.GetMapWidget();
+		if (!canvas)
+		{
+			Print("[ACE_UnitMarkers] CreateMarkerWidget - map canvas null", LogLevel.WARNING);
 			return null;
+		}
 
-		vector pos = ent.GetOrigin();
-		marker.SetWorldPos((int)pos[0], (int)pos[2]);
-		marker.SetCustomText(BuildMarkerLabel(ent));
+		WorkspaceWidget workspace = GetGame().GetWorkspace();
 
-		// true = local-only, not broadcast over network
-		markerManager.InsertStaticMarker(marker, true);
-		return marker;
+		// Root frame - positioned via FrameSlot, children use absolute positions within it
+		Widget root = workspace.CreateWidget(WidgetType.FrameWidgetTypeID, WidgetFlags.VISIBLE, new Color(1, 1, 1, 1), 0, canvas);
+		if (!root)
+		{
+			Print("[ACE_UnitMarkers] CreateMarkerWidget - failed to create root frame", LogLevel.WARNING);
+			return null;
+		}
+
+		Color factionColor = GetFactionColor(ent);
+
+		// Icon image - centered on the anchor point
+		ImageWidget icon = ImageWidget.Cast(workspace.CreateWidget(WidgetType.ImageWidgetTypeID, WidgetFlags.VISIBLE, factionColor, 0, root));
+		if (icon)
+		{
+			icon.LoadImageFromSet(0, MILITARY_IMAGESET, GetIconName(ent));
+			FrameSlot.SetSize(icon, MARKER_SIZE_PX, MARKER_SIZE_PX);
+			FrameSlot.SetPos(icon, -MARKER_SIZE_PX * 0.5, -MARKER_SIZE_PX * 0.5);
+		}
+
+		// Label text - below the icon
+		TextWidget label = TextWidget.Cast(workspace.CreateWidget(WidgetType.TextWidgetTypeID, WidgetFlags.VISIBLE, factionColor, 0, root));
+		if (label)
+		{
+			label.SetText(BuildMarkerLabel(ent));
+			FrameSlot.SetPos(label, -MARKER_SIZE_PX * 0.5, MARKER_SIZE_PX * 0.5);
+		}
+
+		// Position on map
+		RefreshMarkerWidget(root, ent);
+
+		Print(string.Format("[ACE_UnitMarkers] CreateMarkerWidget - created for entity %1", ent.GetName()), LogLevel.NORMAL);
+		return root;
 	}
 
 	//------------------------------------------------------------------------------------------------
-	protected void RefreshMarker(SCR_MapMarkerBase marker, IEntity ent)
+	protected void RefreshMarkerWidget(Widget root, IEntity ent)
 	{
-		if (!marker || !ent)
+		if (!root || !ent)
 			return;
 
 		vector pos = ent.GetOrigin();
-		marker.SetWorldPos((int)pos[0], (int)pos[2]);
-		marker.SetCustomText(BuildMarkerLabel(ent));
+		int screenX, screenY;
+		m_MapEntity.WorldToScreen(pos[0], pos[2], screenX, screenY, true);
+
+		WorkspaceWidget workspace = GetGame().GetWorkspace();
+		FrameSlot.SetPos(root, workspace.DPIUnscale(screenX), workspace.DPIUnscale(screenY));
+
+		// Update label text (second child of root)
+		Widget firstChild = root.GetChildren();
+		if (firstChild)
+		{
+			TextWidget label = TextWidget.Cast(firstChild.GetSibling());
+			if (label)
+				label.SetText(BuildMarkerLabel(ent));
+		}
 	}
 
 	//------------------------------------------------------------------------------------------------
-	protected EMilitarySymbolIdentity GetEntityIdentity(IEntity ent)
-	{
-		FactionAffiliationComponent factionComp = FactionAffiliationComponent.Cast(
-			ent.FindComponent(FactionAffiliationComponent)
-		);
-		if (!factionComp)
-			return EMilitarySymbolIdentity.UNKNOWN;
-
-		Faction faction = factionComp.GetAffiliatedFaction();
-		if (!faction)
-			return EMilitarySymbolIdentity.UNKNOWN;
-
-		return ResolveIdentityForFaction(faction.GetFactionKey());
-	}
-
-	//------------------------------------------------------------------------------------------------
-	//! Maps vanilla Reforger faction keys to NATO military symbol identities.
-	//! Extend this list to support custom faction keys from other mods or missions.
-	protected EMilitarySymbolIdentity ResolveIdentityForFaction(string factionKey)
-	{
-		if (factionKey == "US" || factionKey == "US_Army" || factionKey == "NATO" || factionKey == "BLUFOR")
-			return EMilitarySymbolIdentity.BLUFOR;
-
-		if (factionKey == "USSR" || factionKey == "Soviet" || factionKey == "OPFOR" || factionKey == "RU")
-			return EMilitarySymbolIdentity.OPFOR;
-
-		if (factionKey == "FIA" || factionKey == "INDFOR" || factionKey == "Guerrilla" || factionKey == "Resistance")
-			return EMilitarySymbolIdentity.INDFOR;
-
-		return EMilitarySymbolIdentity.UNKNOWN;
-	}
-
-	//------------------------------------------------------------------------------------------------
-	//! Assigns the NATO military symbol icon and operational dimension for an entity.
-	//! Helicopters use the AIR dimension (circle frame).
-	//! Armed ground vehicles receive the ARMOR icon; unarmed ones receive MOTORIZED.
-	//! Infantry always receive the INFANTRY icon on the LAND dimension.
-	protected void GetEntitySymbol(IEntity ent, out EMilitarySymbolIcon icon, out EMilitarySymbolDimension dimension)
+	protected string GetIconName(IEntity ent)
 	{
 		if (ChimeraCharacter.Cast(ent))
-		{
-			icon = EMilitarySymbolIcon.INFANTRY;
-			dimension = EMilitarySymbolDimension.LAND;
-			return;
-		}
+			return "infantry";
 
 		Vehicle vehicle = Vehicle.Cast(ent);
 		if (vehicle)
 		{
 			if (vehicle.FindComponent(HelicopterControllerComponent))
-			{
-				icon = EMilitarySymbolIcon.ROTARY_WING;
-				dimension = EMilitarySymbolDimension.AIR;
-				return;
-			}
+				return "helicopter";
 
-			// Armed ground vehicles (tanks, IFVs, armed APCs) get the ARMOR symbol;
-			// unarmed transports (trucks, jeeps) get the MOTORIZED symbol.
 			if (vehicle.FindComponent(TurretControllerComponent))
-				icon = EMilitarySymbolIcon.ARMOR;
-			else
-				icon = EMilitarySymbolIcon.MOTORIZED;
+				return "armor";
 
-			dimension = EMilitarySymbolDimension.LAND;
-			return;
+			return "motorized";
 		}
 
-		icon = EMilitarySymbolIcon.INFANTRY;
-		dimension = EMilitarySymbolDimension.LAND;
+		return "infantry";
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Builds the text label shown beneath the marker.
-	//! Infantry: player name (if applicable) + cardinal direction in brackets, e.g. "Smith [NE]".
-	//! Vehicles: player name of the driver if player-controlled, otherwise empty.
+	protected Color GetFactionColor(IEntity ent)
+	{
+		FactionAffiliationComponent factionComp = FactionAffiliationComponent.Cast(ent.FindComponent(FactionAffiliationComponent));
+		if (factionComp)
+		{
+			Faction faction = factionComp.GetAffiliatedFaction();
+			if (faction)
+			{
+				string key = faction.GetFactionKey();
+
+				if (key == "US" || key == "US_Army" || key == "NATO" || key == "BLUFOR")
+					return new Color(0.2, 0.4, 1, 1); // blue
+
+				if (key == "USSR" || key == "Soviet" || key == "OPFOR" || key == "RU")
+					return new Color(1, 0.2, 0.2, 1); // red
+
+				if (key == "FIA" || key == "INDFOR" || key == "Guerrilla" || key == "Resistance")
+					return new Color(0.2, 0.8, 0.2, 1); // green
+			}
+		}
+
+		return new Color(1, 1, 1, 1); // white = unknown
+	}
+
+	//------------------------------------------------------------------------------------------------
 	protected string BuildMarkerLabel(IEntity ent)
 	{
 		string playerName = string.Empty;
@@ -312,15 +322,11 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Returns a cardinal direction string for the entity's current facing, e.g. "[NE]".
-	//! Uses the forward vector from the entity's world transform matrix.
-	//! In Enfusion: X=east, Z=north; yaw 0=north, increasing clockwise.
 	protected string GetCardinalDirection(IEntity ent)
 	{
 		vector mat[4];
 		ent.GetWorldTransform(mat);
 
-		// mat[2] is the forward (look) direction in world space
 		float yaw = Math.Atan2(mat[2][0], mat[2][2]) * Math.RAD2DEG;
 		if (yaw < 0)
 			yaw += 360;
@@ -336,41 +342,25 @@ class ACE_UnitMarkers_MapModule : SCR_MapUIBaseComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	protected void RemoveMarkerAt(SCR_MapMarkerManagerComponent markerManager, int idx)
+	protected void RemoveMarkerAt(int idx)
 	{
-		if (m_aMarkers[idx])
-			markerManager.RemoveStaticMarker(m_aMarkers[idx]);
+		if (m_aWidgets[idx])
+			m_aWidgets[idx].RemoveFromHierarchy();
 
 		m_aTrackedEntities.Remove(idx);
-		m_aMarkers.Remove(idx);
+		m_aWidgets.Remove(idx);
 	}
 
 	//------------------------------------------------------------------------------------------------
 	protected void ClearAllMarkers()
 	{
-		SCR_MapMarkerManagerComponent markerManager = GetMarkerManager();
-		if (markerManager)
+		foreach (Widget w : m_aWidgets)
 		{
-			foreach (SCR_MapMarkerBase marker : m_aMarkers)
-			{
-				if (marker)
-					markerManager.RemoveStaticMarker(marker);
-			}
+			if (w)
+				w.RemoveFromHierarchy();
 		}
 
 		m_aTrackedEntities.Clear();
-		m_aMarkers.Clear();
-	}
-
-	//------------------------------------------------------------------------------------------------
-	protected SCR_MapMarkerManagerComponent GetMarkerManager()
-	{
-		BaseGameMode gameMode = GetGame().GetGameMode();
-		if (!gameMode)
-			return null;
-
-		return SCR_MapMarkerManagerComponent.Cast(
-			gameMode.FindComponent(SCR_MapMarkerManagerComponent)
-		);
+		m_aWidgets.Clear();
 	}
 }

--- a/addons/unit_markers/test/worlds/markertest.ent
+++ b/addons/unit_markers/test/worlds/markertest.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{C7DC72AF0AE17724}worlds/Arland/EmptyArland.ent"
+}

--- a/addons/unit_markers/test/worlds/markertest.ent.meta
+++ b/addons/unit_markers/test/worlds/markertest.ent.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{45EBE7AE233357CD}test/worlds/markertest.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/addons/unit_markers/test/worlds/markertest_Layers/default.layer
+++ b/addons/unit_markers/test/worlds/markertest_Layers/default.layer
@@ -57,5 +57,9 @@ PerceptionManager PerceptionManager : "{028DAEAD63E056BE}Prefabs/World/Game/Perc
  coords 1643.069 -8.342 1364.757
 }
 SCR_GameModeEditor GameMode_Editor_Full : "{DA3986AF1B5032B7}Prefabs/MP/Modes/Editor/GameMode_Editor_Full.et" {
+ components {
+  ACE_UnitMarkers_MapInjectorComponent "{696D2C3232BE79FF}" {
+  }
+ }
  coords 1643.069 -8.214 1363.757
 }

--- a/addons/unit_markers/test/worlds/markertest_Layers/default.layer
+++ b/addons/unit_markers/test/worlds/markertest_Layers/default.layer
@@ -1,0 +1,61 @@
+SCR_MapEntity MapEntity : "{731564B66F91B107}Prefabs/World/Game/MapEntity.et" {
+ coords 1643.069 -8.604 1366.757
+ "Map Geometry Data" "{0DD089CCD442399A}worlds/Arland/Arland.topo"
+ "Satellite background image" "{F98F3D2CBA523091}UI/Textures/Map/worlds/Arland/ArlandRasterized.edds"
+ {
+  CommentEntity {
+   coords 0 1 0
+   m_Comment "MapEntity: "\
+   "Set up map textures"
+   m_Color 0 0 0
+   m_FaceCamera 1
+   m_TextBackground 1
+   m_BackgroundColor 1 0.6 0
+   m_BackgroundTransparency 0
+  }
+ }
+}
+SCR_AIWorld SCR_AIWorld : "{E0A05C76552E7F58}Prefabs/AI/SCR_AIWorld.et" {
+ components {
+  NavmeshWorldComponent "{5584F30E67F617AD}" {
+   NavmeshSettings NavmeshWorld "{50FC63BEBE3973C5}" {
+    NavmeshFilesConfig BaseNavmeshFilesConfig "{696D25AB4CC332D3}" {
+     NavmeshFile "{804386FFEB7B7EFD}worlds/MP/Navmeshes/LowResArland.nmn"
+    }
+   }
+  }
+  NavmeshWorldComponent "{5584F30EEFEE1223}" {
+   NavmeshSettings ChimeraNavmeshWorld "{50FC63BEBE3973C5}" {
+    NavmeshFilesConfig BaseNavmeshFilesConfig "{60CA9BE5536BF701}" {
+     NavmeshFile "{D8EF7131FB31AF97}worlds/GameMaster/Navmeshes/GM_Arland.nmn"
+    }
+   }
+  }
+  NavmeshWorldComponent "{5C8C9B750D124A63}" {
+   NavmeshSettings NavmeshWorld "{5C8C9B750B60C6E2}" {
+    NavmeshFilesConfig BaseNavmeshFilesConfig "{5C90BD0EC793647D}" {
+     NavmeshFile "{A0AEEB1E7EF474FA}worlds/GameMaster/Navmeshes/GM_Arland_vehicles.nmn"
+    }
+   }
+  }
+ }
+ coords 1643.069 -8.467 1365.757
+ {
+  CommentEntity {
+   coords 0 1 0
+   m_Comment "SCR_AIWorld: "\
+   "Configure navigation mesh"
+   m_Color 0 0 0
+   m_FaceCamera 1
+   m_TextBackground 1
+   m_BackgroundColor 1 0.6 0
+   m_BackgroundTransparency 0
+  }
+ }
+}
+PerceptionManager PerceptionManager : "{028DAEAD63E056BE}Prefabs/World/Game/PerceptionManager.et" {
+ coords 1643.069 -8.342 1364.757
+}
+SCR_GameModeEditor GameMode_Editor_Full : "{DA3986AF1B5032B7}Prefabs/MP/Modes/Editor/GameMode_Editor_Full.et" {
+ coords 1643.069 -8.214 1363.757
+}


### PR DESCRIPTION
Adds a new addon (ACE_UnitMarkers) that shows NATO military symbol markers on the fullscreen map for players with gamemaster authority.

- Infantry units display the INFANTRY NATO symbol (rectangle) with a cardinal direction indicator, e.g. "Smith [NE]"
- Helicopters display the ROTARY_WING symbol in the AIR dimension (circle)
- Armed ground vehicles (tanks, IFVs, armed APCs) display the ARMOR symbol
- Unarmed ground transports display the MOTORIZED symbol
- All markers are faction-colored: BLUFOR=blue, OPFOR=red, INDFOR=green
- Markers are local-only (not networked) and update every 1.5 s
- Markers are only visible when the local player has a non-limited editor (GM) instance and the map is open

https://claude.ai/code/session_016mBhosZQDpm9GpuJQFBJWK

**When merged this pull request will:**
- _Describe what this pull request will do_
- _Each change in a separate line_

### IMPORTANT

- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
