### PR TITLE
Medical Hitzones - Turn off damage spillovers to torso

### DIFF
--- a/addons/medical_hitzones/scripts/Game/ACE_Medical_Hitzones/HitZone/SCR_LimbDamagePassRule.c
+++ b/addons/medical_hitzones/scripts/Game/ACE_Medical_Hitzones/HitZone/SCR_LimbDamagePassRule.c
@@ -1,0 +1,12 @@
+//------------------------------------------------------------------------------------------------
+[BaseContainerProps(), SCR_DamagePassRuleContainerTitle()]
+modded class SCR_LimbDamagePassRule : SCR_BaseDamagePassRule
+{
+	//------------------------------------------------------------------------------------------------
+	//! Turn off spillovers to other hit zone groups
+	override void HandlePassedDamage(inout notnull BaseDamageContext damageContext, notnull SCR_HitZone srcHitZone, notnull SCR_DamageManagerComponent dmgManager)
+	{
+		m_eSpilloverHitZoneGroup = -1;
+		super.HandlePassedDamage(damageContext, srcHitZone, dmgManager);
+	}
+}


### PR DESCRIPTION
**When merged this pull request will:**
- Disable damage spillovers to torso

**Background:**
- Vanilla damage system got updated, such that when limbs are destroyed, they can pass damage to torso, which is undesired, as a core point of the hitzones mod is that damage to limbs should no longer directly kill the character or trigger second chance.

**Requires:**
- #399 