### PR TITLE
﻿fix: adapt to Reforger 1.7 script parser and persistence API changes

### DIFF
--- a/addons/core/scripts/Game/ACE_Core/Systems/Persistence/Serializers/States/ACE_LoadtimeEntityManagerStateSerializer.c
+++ b/addons/core/scripts/Game/ACE_Core/Systems/Persistence/Serializers/States/ACE_LoadtimeEntityManagerStateSerializer.c
@@ -11,39 +11,44 @@ class ACE_LoadtimeEntityManagerStateSerializer : ScriptedStateSerializer
 	{
 		return ACE_LoadtimeEntityManagerState;
 	}
-	
+
 	//------------------------------------------------------------------------------------------------
-	override ESerializeResult Serialize(notnull Managed instance, notnull BaseSerializationSaveContext context)
+	//! Reforger 1.7: persistence contexts were renamed. The old
+	//! `BaseSerializationSaveContext` / `BaseSerializationLoadContext` are gone; the parent
+	//! `ScriptedStateSerializer` now uses `SaveContext` / `LoadContext`. With the new parameter
+	//! types the `override` of these `event` methods is accepted again (Bohemia's own subclasses
+	//! such as SCR_TaskSystemSerializer / SCR_PlayerReconnectDataSerializer use the same form).
+	override ESerializeResult Serialize(notnull Managed instance, notnull SaveContext context)
 	{
 		ACE_LoadtimeEntityManager manager = ACE_LoadtimeEntityManager.GetInstance();
 		if (!manager)
 			return ESerializeResult.DEFAULT;
-		
+
 		array<EntityID> deletedEntityIDs = manager.GetDeletedEntityIDs();
 		if (deletedEntityIDs.IsEmpty())
 			return ESerializeResult.DEFAULT;
-		
+
 		context.WriteValue("version", 1);
-		
+
 		array<string> stringifiedIDs = {};
 		stringifiedIDs.Reserve(deletedEntityIDs.Count());
-		
+
 		foreach (EntityID entityID : deletedEntityIDs)
 		{
 			stringifiedIDs.Insert(ACE_EntityIdHelper.ToString(entityID));
 		}
-		
+
 		context.WriteValue("deletedEntityIDs", stringifiedIDs);
 		return ESerializeResult.OK;
 	}
 
 	//------------------------------------------------------------------------------------------------
-	override bool Deserialize(notnull Managed instance, notnull BaseSerializationLoadContext context)
+	override bool Deserialize(notnull Managed instance, notnull LoadContext context)
 	{
 		ACE_LoadtimeEntityManager manager = ACE_LoadtimeEntityManager.GetInstance();
 		if (!manager)
 			return false;
-		
+
 		int version;
 		context.Read(version);
 
@@ -58,7 +63,7 @@ class ACE_LoadtimeEntityManagerStateSerializer : ScriptedStateSerializer
 			if (entityID != EntityID.INVALID)
 				deletedEntityIDs.Insert(entityID);
 		}
-		
+
 		manager.DeleteEntitiesByIdGlobal(deletedEntityIDs);
 		return true;
 	}

--- a/addons/core/scripts/Game/ACE_Core/UI/HUD/AvailableActions/Conditions/ACE_IsCharacterCarrierCondition.c
+++ b/addons/core/scripts/Game/ACE_Core/UI/HUD/AvailableActions/Conditions/ACE_IsCharacterCarrierCondition.c
@@ -4,11 +4,8 @@ class ACE_IsCharacterCarrierCondition : SCR_AvailableActionCondition
 {
 	//------------------------------------------------------------------------------------------------
 	//! Returns true if the release action is available
-	override bool IsAvailable(SCR_AvailableActionsConditionData data)
+	override bool IsAvailable(notnull SCR_AvailableActionsConditionData data)
 	{
-		if (!data)
-			return false;
-		
 		return GetReturnResult(data.ACE_GetIsCharacterCarrier());
 	}
 }

--- a/addons/facepaint/scripts/Game/ACE_Facepaint/UI/HUD/AvailableActions/Conditions/Game/Character/ACE_CharacterAppliedFacepaintCondition.c
+++ b/addons/facepaint/scripts/Game/ACE_Facepaint/UI/HUD/AvailableActions/Conditions/Game/Character/ACE_CharacterAppliedFacepaintCondition.c
@@ -4,11 +4,8 @@
 class ACE_CharacterAppliedFacepaintCondition : SCR_AvailableActionCondition
 {
 	//------------------------------------------------------------------------------------------------
-	override bool IsAvailable(SCR_AvailableActionsConditionData data)
+	override bool IsAvailable(notnull SCR_AvailableActionsConditionData data)
 	{
-		if (!data)
-			return false;
-		
 		ChimeraCharacter char = data.GetCharacter();
 		if (!char)
 			return false;


### PR DESCRIPTION
Reforger 1.7 (Partisan Update, 28 May 2026) tightened the EnScript parser and renamed the persistence serialization context types. The current `master` branch no longer builds against 1.7. This commit restores compatibility without dropping any existing functionality.

1. Persistence serialization contexts were renamed in 1.7: BaseSerializationSaveContext -> SaveContext BaseSerializationLoadContext -> LoadContext The parent `ScriptedStateSerializer` event signatures changed accordingly. The ACE override therefore failed to compile with: "Overloading event 'Serialize' is not allowed" because the overriding method had a different parameter type than the parent and was being interpreted as an overload, not an override.

   - `ACE_LoadtimeEntityManagerStateSerializer.Serialize` and `Deserialize` are now declared with `SaveContext` / `LoadContext`, matching the new parent signature. The override is accepted again and the cross-save tracking of deleted entity IDs is fully preserved (verified against Bohemias own 1.7 subclasses `SCR_TaskSystemSerializer` and `SCR_PlayerReconnectDataSerializer`, which use the exact same pattern).

2. `SCR_AvailableActionCondition.IsAvailable` now declares the `data` parameter as `notnull`. Overrides must match the qualifier or the compiler reports a signature mismatch.
     - Updated `ACE_IsCharacterCarrierCondition.IsAvailable` - Updated `ACE_CharacterAppliedFacepaintCondition.IsAvailable` - The redundant `if (!data) return false;` early-out is removed because `notnull` already guarantees the parameter.

Without these changes the `Game` script module fails to compile and ACE cannot be loaded in Workbench or in a packed mod on Reforger 1.7+.

Tested locally on Reforger 1.7.0.228: `Game` module compiles with zero ACE-related errors. No regressions; all serializer behaviour preserved.

**When merged this pull request will:**
- _Describe what this pull request will do_
- _Each change in a separate line_

### IMPORTANT

- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
