### PR TITLE
Carrying - Fix exploits and crashes

### DIFF
--- a/addons/captives/Prefabs/Helpers/ACE_Captives_SurrenderHelperCompartment.et
+++ b/addons/captives/Prefabs/Helpers/ACE_Captives_SurrenderHelperCompartment.et
@@ -1,6 +1,14 @@
 ACE_Captives_SurrenderHelperCompartment : "{0D226790BE615DC7}Prefabs/Helpers/ACE_AnimationHelperCompartment.et" {
  ID "4B42E71698F5739C"
  components {
+  SCR_BaseCompartmentManagerComponent "{2CD4A765A7D52986}" {
+   CompartmentSlots {
+    CargoCompartmentSlot Performer {
+     GetOutAction SCR_GetOutAction "{69AD265674DA6E68}" {
+     }
+    }
+   }
+  }
   VehicleAnimationComponent "{50B812962B17E60B}" {
    AnimInstance "{EF71DF39A69DC55A}Assets/Helpers/Workspace/ACE_Captives_Surrender.asi"
    AnimInjection AnimationAttachmentInfo "{50B812961A339FD2}" {

--- a/addons/captives/Prefabs/Helpers/ACE_Captives_TiedHelperCompartment.et
+++ b/addons/captives/Prefabs/Helpers/ACE_Captives_TiedHelperCompartment.et
@@ -12,7 +12,7 @@ ACE_Captives_TiedHelperCompartment : "{0D226790BE615DC7}Prefabs/Helpers/ACE_Anim
   SCR_BaseCompartmentManagerComponent "{2CD4A765A7D52986}" {
    CompartmentSlots {
     CargoCompartmentSlot Performer {
-     GetOutAction CompartmentUserAction "{64771541B779685D}" {
+     GetOutAction CompartmentUserAction "{69AD26567CC01AEE}" {
      }
     }
    }

--- a/addons/captives/scripts/Game/ACE_Captives/UserActions/SCR_RemoveCasualtyUserAction.c
+++ b/addons/captives/scripts/Game/ACE_Captives/UserActions/SCR_RemoveCasualtyUserAction.c
@@ -25,10 +25,6 @@ modded class SCR_RemoveCasualtyUserAction : SCR_CompartmentUserAction
 		if (!captiveChar)
 			return;
 		
-		SCR_CompartmentAccessComponent captiveCompartmentAccess = SCR_CompartmentAccessComponent.Cast(captiveChar.GetCompartmentAccessComponent());
-		if (captiveCompartmentAccess)
-			captiveCompartmentAccess.KickFromVehicle(GetRelevantDoorIndex(pUserEntity));
-		
 		ACE_AnimationHelperCompartment helper = ACE_AnimationTools.AnimateWithHelperCompartment(ACE_EAnimationHelperID.TIED, captiveChar);
 		if (!helper)
 			return;

--- a/addons/captives/scripts/Game/ACE_Captives/UserActions/SCR_RemoveCasualtyUserAction.c
+++ b/addons/captives/scripts/Game/ACE_Captives/UserActions/SCR_RemoveCasualtyUserAction.c
@@ -115,21 +115,21 @@ modded class SCR_RemoveCasualtyUserAction : SCR_CompartmentUserAction
 		if (!userChar)
 			return false;
 		
-		// Cannot be performed when already carrying
-		SCR_CharacterControllerComponent userCharController = SCR_CharacterControllerComponent.Cast(userChar.GetCharacterController());
-		if (!userCharController || userCharController.ACE_IsCarrier())
-		{
-			SetCannotPerformReason("#ACE-UserAction_Carrying");
-			return false;
-		}
-		
-		SCR_CompartmentAccessComponent compartmentAccess = SCR_CompartmentAccessComponent.Cast(userChar.GetCompartmentAccessComponent());
-		if (!compartmentAccess)
-			return false;
-		
 		BaseCompartmentSlot compartment = GetCompartmentSlot();
 		if (!compartment)
 			return false;
+		
+		SCR_ChimeraCharacter captiveChar = SCR_ChimeraCharacter.Cast(compartment.GetOccupant());
+		if (!captiveChar)
+			return false;
+		
+		string cannotPerformReason;
+		SCR_CharacterControllerComponent userCharController = SCR_CharacterControllerComponent.Cast(userChar.GetCharacterController());
+		if (!userCharController || !userCharController.ACE_CanCarry(captiveChar, cannotPerformReason))
+		{
+			SetCannotPerformReason(cannotPerformReason);
+			return false;
+		}
 		
 		return true;
 	}

--- a/addons/carrying/Prefabs/Helpers/ACE_Carrying_BaseHelperCompartment.et
+++ b/addons/carrying/Prefabs/Helpers/ACE_Carrying_BaseHelperCompartment.et
@@ -11,6 +11,8 @@ ACE_Carrying_HelperCompartment : "{0D226790BE615DC7}Prefabs/Helpers/ACE_Animatio
   SCR_BaseCompartmentManagerComponent "{2CD4A765A7D52986}" {
    CompartmentSlots {
     CargoCompartmentSlot Performer {
+     GetOutAction CompartmentUserAction "{69AD265654380459}" {
+     }
      OverrideEntryPositionInfo PointInfo "{670E0D3DB86D5304}" {
      }
      OverrideExitPositionInfo PointInfo "{670E0D3DB3C80C6C}" {

--- a/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/SCR_RemoveCasualtyUserAction.c
+++ b/addons/carrying/Scripts/Game/ACE_Carrying/UserActions/SCR_RemoveCasualtyUserAction.c
@@ -5,9 +5,6 @@ modded class SCR_RemoveCasualtyUserAction : SCR_CompartmentUserAction
 	//! Initate carry when possible
 	override protected void PerformRemoveCasualtyAction(IEntity pOwnerEntity, IEntity pUserEntity)
 	{
-		// First call the base implementation, which ejects the character from the vehicle
-		super.PerformRemoveCasualtyAction(pOwnerEntity, pUserEntity);
-		
 		BaseCompartmentSlot compartment = GetCompartmentSlot();
 		if (!compartment)
 			return;
@@ -24,12 +21,10 @@ modded class SCR_RemoveCasualtyUserAction : SCR_CompartmentUserAction
 		if (!userCharController)
 			return;
 		
-		// We just eject AI for now. Trying to carrying them immediatly breaks their animation
-		if (!EntityUtils.IsPlayer(casualtyChar))
-			return;
-		
 		string cannotPerformReason;
 		if (userCharController.ACE_Carrying_CanCarryCasualty(casualtyChar, cannotPerformReason))
 			userCharController.ACE_Carrying_CarryCasualty(casualtyChar);
+		else
+			super.PerformRemoveCasualtyAction(pOwnerEntity, pUserEntity); // Just eject them if not carriable
 	}
 }

--- a/addons/core/Prefabs/Helpers/ACE_AnimationHelperCompartment.et
+++ b/addons/core/Prefabs/Helpers/ACE_AnimationHelperCompartment.et
@@ -51,9 +51,6 @@ ACE_AnimationHelperCompartment : "{278E487E19D82680}Prefabs/Vehicles/Core/Vehicl
    m_fDist_Desired 1
    m_fFOV 74
   }
-  ActionsManagerComponent "{2CD4A765B4482F53}" {
-   Enabled 0
-  }
   VehicleAnimationComponent "{50B812962B17E60B}" {
    AnimGraph "{30A78C04E5385196}Assets/Helpers/Workspace/ACE_AnimationHelperCompartment.agr"
    AnimInstance "{A0A5BCBD5629BADB}Assets/Helpers/Workspace/ACE_AnimationHelperCompartment.asi"

--- a/addons/core/Prefabs/Helpers/ACE_AnimationHelperCompartment.et
+++ b/addons/core/Prefabs/Helpers/ACE_AnimationHelperCompartment.et
@@ -19,6 +19,12 @@ ACE_AnimationHelperCompartment : "{278E487E19D82680}Prefabs/Vehicles/Core/Vehicl
    }
    CompartmentSlots {
     CargoCompartmentSlot Performer {
+     CompartmentAction CompartmentUserAction "{69AD265658BC24AA}" {
+     }
+     JumpOutAction CompartmentUserAction "{69AD265659781649}" {
+     }
+     SwitchSeatAction CompartmentUserAction "{69AD26565F43CFA0}" {
+     }
      PassengerPositionInfo EntitySlotInfo s1 {
      }
      ForcedFreeLook 1

--- a/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterControllerComponent.c
+++ b/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterControllerComponent.c
@@ -73,6 +73,10 @@ modded class SCR_CharacterControllerComponent : CharacterControllerComponent
 	//------------------------------------------------------------------------------------------------
 	bool ACE_CanCarry(IEntity entity, out string cannotPerformReason)
 	{
+		SCR_ChimeraCharacter ownerChar = SCR_ChimeraCharacter.Cast(GetOwner());
+		if (!ownerChar || ownerChar.IsInVehicle())
+			return false;
+		
 		if (ACE_IsCarrier())
 		{
 			cannotPerformReason = "#ACE-UserAction_Carrying";

--- a/addons/core/scripts/Game/ACE_Core/Vehicle/SCR_CompartmentAccessComponent.c
+++ b/addons/core/scripts/Game/ACE_Core/Vehicle/SCR_CompartmentAccessComponent.c
@@ -5,10 +5,6 @@ modded class SCR_CompartmentAccessComponent : CompartmentAccessComponent
 	protected bool m_bACE_IsRequestingGettingIn = false;
 	protected bool m_bACE_IsRequestingGettingOut = false;
 	
-	// Parameters for rescheduling failed get in/out
-	protected static const int ATTEMPT_TIMEOUT = 500;
-	protected static const int MAX_ATTEMPTS = 20;
-	
 	//------------------------------------------------------------------------------------------------
 	void ACE_GetInVehicle(notnull IEntity vehicle, BaseCompartmentSlot compartment = null, bool forceTeleport = true, int doorInfoIndex = -1, ECloseDoorAfterActions closeDoor = ECloseDoorAfterActions.INVALID, bool performWhenPaused = false)
 	{
@@ -20,12 +16,12 @@ modded class SCR_CompartmentAccessComponent : CompartmentAccessComponent
 			return;
 		
 		ACE_SetIsRequestingGettingIn(true);
-		Rpc(RpcDo_ACE_GetInVehicle_Owner, vehicleRpl.Id(), compartment.GetCompartmentSlotID(), compartment.GetCompartmentMgrID(), forceTeleport, doorInfoIndex, closeDoor, performWhenPaused, 0);
+		Rpc(RpcDo_ACE_GetInVehicle_Owner, vehicleRpl.Id(), compartment.GetCompartmentSlotID(), compartment.GetCompartmentMgrID(), forceTeleport, doorInfoIndex, closeDoor, performWhenPaused);
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Owner)]
-	protected void RpcDo_ACE_GetInVehicle_Owner(RplId vehicleID, int slotID, int mgrID, bool forceTeleport, int doorInfoIndex, ECloseDoorAfterActions closeDoor, bool performWhenPaused, int iAttempt)
+	protected void RpcDo_ACE_GetInVehicle_Owner(RplId vehicleID, int slotID, int mgrID, bool forceTeleport, int doorInfoIndex, ECloseDoorAfterActions closeDoor, bool performWhenPaused)
 	{
 
 		RplComponent vehicleRpl = RplComponent.Cast(Replication.FindItem(vehicleID));
@@ -56,27 +52,8 @@ modded class SCR_CompartmentAccessComponent : CompartmentAccessComponent
 			return;
 		}
 		
-		if (GetInVehicle(vehicle, compartment, forceTeleport, doorInfoIndex, closeDoor, performWhenPaused))
-		{
-			ACE_SetIsRequestingGettingIn(false);
-			return;
-		}
-		
-		if (GetVehicleIn(GetOwner()) == vehicle)
-		{
-			ACE_SetIsRequestingGettingIn(false);
-			return;
-		}
-		
-		if (++iAttempt >= MAX_ATTEMPTS)
-		{
-			Debug.Error("Maximum number of attempts exceeded!");
-			ACE_SetIsRequestingGettingIn(false);
-			return;
-		}
-		
-		// Reschedule moving out if it failed, for instance, when called while moving out
-		GetGame().GetCallqueue().CallLater(RpcDo_ACE_GetInVehicle_Owner, ATTEMPT_TIMEOUT, false, vehicleID, slotID, mgrID, forceTeleport, doorInfoIndex, closeDoor, performWhenPaused, iAttempt);
+		GetInVehicle(vehicle, compartment, forceTeleport, doorInfoIndex, closeDoor, performWhenPaused);
+		ACE_SetIsRequestingGettingIn(false);
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -123,71 +100,32 @@ modded class SCR_CompartmentAccessComponent : CompartmentAccessComponent
 	void ACE_MoveOutVehicle(vector target_transform[4], bool sendIntoRagdoll = false, bool performWhenPaused = false)
 	{
 		ACE_SetIsRequestingGettingOut(true);
-		Rpc(RpcDo_ACE_MoveOutVehicle_Owner, target_transform[0], target_transform[1], target_transform[2], target_transform[3], sendIntoRagdoll, performWhenPaused, 0);
+		Rpc(RpcDo_ACE_MoveOutVehicle_Owner, target_transform[0], target_transform[1], target_transform[2], target_transform[3], sendIntoRagdoll, performWhenPaused);
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	//! Transform is passed in parts, since fixed arrays are not supported by ScriptCallQueue::CallLater
 	[RplRpc(RplChannel.Reliable, RplRcver.Owner)]
-	protected void RpcDo_ACE_MoveOutVehicle_Owner(vector v0, vector v1, vector v2, vector v3, bool sendIntoRagdoll, bool performWhenPaused, int iAttempt)
+	protected void RpcDo_ACE_MoveOutVehicle_Owner(vector v0, vector v1, vector v2, vector v3, bool sendIntoRagdoll, bool performWhenPaused)
 	{
 		vector target_transform[4] = {v0, v1, v2, v3};
-		
-		if (GetOutVehicle_NoDoor(target_transform, sendIntoRagdoll, performWhenPaused))
-		{
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		if (!GetVehicleIn(GetOwner()))
-		{
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		if (++iAttempt >= MAX_ATTEMPTS)
-		{
-			Debug.Error("Maximum number of attempts exceeded!");
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		// Reschedule moving out if it failed, for instance, when called while moving in
-		GetGame().GetCallqueue().CallLater(RpcDo_ACE_MoveOutVehicle_Owner, ATTEMPT_TIMEOUT, false, v0, v1, v2, v3, sendIntoRagdoll, performWhenPaused, iAttempt);
+		GetOutVehicle_NoDoor(target_transform, sendIntoRagdoll, performWhenPaused);
+		ACE_SetIsRequestingGettingOut(false);
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	void ACE_GetOutVehicle(EGetOutType type, int doorInfoIndex, ECloseDoorAfterActions closeDoor, bool performWhenPaused)
 	{
 		ACE_SetIsRequestingGettingOut(true);
-		Rpc(RpcDo_ACE_GetOutVehicle_Owner, type, doorInfoIndex, closeDoor, performWhenPaused, 0);
+		Rpc(RpcDo_ACE_GetOutVehicle_Owner, type, doorInfoIndex, closeDoor, performWhenPaused);
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Owner)]
-	protected void RpcDo_ACE_GetOutVehicle_Owner(EGetOutType type, int doorInfoIndex, ECloseDoorAfterActions closeDoor, bool performWhenPaused, int iAttempt)
+	protected void RpcDo_ACE_GetOutVehicle_Owner(EGetOutType type, int doorInfoIndex, ECloseDoorAfterActions closeDoor, bool performWhenPaused)
 	{
-		if (GetOutVehicle(type, doorInfoIndex, closeDoor, performWhenPaused))
-		{
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		if (!GetVehicleIn(GetOwner()))
-		{
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		if (++iAttempt >= MAX_ATTEMPTS)
-		{
-			Debug.Error("Maximum number of attempts exceeded!");
-			ACE_SetIsRequestingGettingOut(false);
-			return;
-		}
-		
-		// Reschedule getting out if it failed, for instance, when called while getting in
-		GetGame().GetCallqueue().CallLater(RpcDo_ACE_GetOutVehicle_Owner, ATTEMPT_TIMEOUT, false, type, doorInfoIndex, closeDoor, performWhenPaused, iAttempt);
+		GetOutVehicle(type, doorInfoIndex, closeDoor, performWhenPaused);
+		ACE_SetIsRequestingGettingOut(false);
 	}
 	
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**When merged this pull request will:**
- Fix issue that carrying/escort can be initated while user is in vehicle.
- Fix that patient could exit compartment via get out action keybind (fixed by explicitly assign unimplemented compartment action `CompartmentUserAction`).
- Directly move character in helper compartment when using `SCR_RemoveCasualtyUserAction` instead of ejecting them from the vehicle first
- Remove attempt loops from ACE's move in/out methods
- Fix missing `ActionsManagerComponent` warning for helper compartment
