### PR TITLE
Core - Fix VME when initiating new loitering action while loitering

### DIFF
--- a/addons/core/scripts/Game/ACE_Core/Commanding/Commands/SCR_ContinuousLoiterCommand.c
+++ b/addons/core/scripts/Game/ACE_Core/Commanding/Commands/SCR_ContinuousLoiterCommand.c
@@ -25,4 +25,23 @@ modded class SCR_ContinuousLoiterCommand : SCR_BaseRadialCommand
 		
 		return true;
 	}
+	
+	//------------------------------------------------------------------------------------------------
+	//! Fix missing assignment of m_pScrInputContext in vanilla implementation
+	override bool Execute(IEntity cursorTarget, IEntity target, vector targetPosition, int playerID, bool isClient)
+	{
+		if (SCR_PlayerController.GetLocalPlayerId() != playerID)
+			return true;
+		
+		IEntity playerControlledEntity = GetGame().GetPlayerController().GetControlledEntity();		
+		if (!playerControlledEntity)
+			return false;
+		
+		SCR_CharacterControllerComponent characterController = SCR_CharacterControllerComponent.Cast(playerControlledEntity.FindComponent(SCR_CharacterControllerComponent));
+		if (!characterController)
+			return false;
+		
+		m_pScrInputContext = characterController.GetScrInputContext();
+		return super.Execute(cursorTarget, target, targetPosition, playerID, isClient);
+	}
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Fix VME from unassigned `m_pScrInputContext` in vanilla implementation of `SCR_ContinuousLoiterCommand::Execute`

**Background:**
- Loitering is used for running continuous gestures like push ups and sitting.