### PR TITLE
Medical Breathing - Remove GetTemperature method

### DIFF
--- a/addons/medical_breathing/scripts/Game/ACE_Medical_Breathing/Components/ACE_Medical_VitalsComponent.c
+++ b/addons/medical_breathing/scripts/Game/ACE_Medical_Breathing/Components/ACE_Medical_VitalsComponent.c
@@ -118,13 +118,7 @@ modded class ACE_Medical_VitalsComponent : ACE_BaseComponent
 	{
 		return m_fCvenCO2;
 	}
-	
-	//------------------------------------------------------------------------------------------------
-	//! Returns body temperature in K
-	float GetTemperature()
-	{
-		return 310.15;
-	}
+
 	
 	//------------------------------------------------------------------------------------------------
 	//! Sets extend of pneumothorax


### PR DESCRIPTION
When merged this pull request will:
- Get rid of the unused GetTemperature method in breathing, to help compatability between future prs

Requires
- [#281 Medical - Add breathing](github.com/acemod/ACE-Anvil/pulls/281)
- #463 Add setter/getter methods in circulation