### PR TITLE
Core - Fix HandleWeaponFire override to call super

### DIFF
--- a/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterCommandHandlerComponent.c
+++ b/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterCommandHandlerComponent.c
@@ -19,7 +19,7 @@ modded class SCR_CharacterCommandHandlerComponent : CharacterCommandHandlerCompo
 			m_bACE_ForceWeaponFire = false;
 		}
 		
-		return HandleWeaponFireDefault(pInputCtx, pDt, pCurrentCommandID);
+		return super.HandleWeaponFire(pInputCtx, pDt, pCurrentCommandID);
 	}
 	
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**When merged this pull request will:**
Return `super.HandleWeaponFire()` instead of `HandleWeaponFireDefault()` so that this mod works with other mods that override `HandleWeaponFire()`.
