### PR TITLE
Core - Fix HandleWeaponFire override to call super

### DIFF
--- a/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterCommandHandlerComponent.c
+++ b/addons/core/scripts/Game/ACE_Core/Character/SCR_CharacterCommandHandlerComponent.c
@@ -8,6 +8,8 @@ modded class SCR_CharacterCommandHandlerComponent : CharacterCommandHandlerCompo
 	//------------------------------------------------------------------------------------------------
 	override bool HandleWeaponFire(CharacterInputContext pInputCtx, float pDt, int pCurrentCommandID)
 	{
+		super.HandleWeaponFire(pInputCtx, pDt, pCurrentCommandID);
+		
 		if (!m_bACE_CanHandleWeaponFire)
 			return false;
 		


### PR DESCRIPTION
**When merged this pull request will:**
Call `super.HandleWeaponFire()` during `HandleWeaponFire()` so that this mod works with other mods that override HandleWeaponFire().

### Testing
Tested that firing works and that mod compatibility is fixed.